### PR TITLE
NX46: réintégration de la détection notebook et bootstrap offline des dépendances (v3)

### DIFF
--- a/RAPPORT-VESUVIUS/RAPPORT_AUDIT_CRITIQUE_V2_ZERO_OUTPUT_NX46.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_AUDIT_CRITIQUE_V2_ZERO_OUTPUT_NX46.md
@@ -1,0 +1,189 @@
+# RAPPORT D'AUDIT CRITIQUE — NX46 V2 « tout à zéro »
+
+## 1) Contexte et objectif
+
+Tu as signalé un état final avec:
+- `layout_detected: "empty"`
+- toutes les métriques opérationnelles à zéro (`active_neurons`, `total_allocations`, `total_pixels_processed`, etc.)
+- aucune sortie de soumission (`submission_csv: null`, `submission_zip: null`).
+
+Objectif de cet audit: expliquer **pourquoi** cela arrive, **où** le comportement diverge des notebooks de référence qui fonctionnent, et proposer un plan de correction strict, clair, pédagogique, sans flou.
+
+---
+
+## 2) Résultat de l’inspection des artefacts disponibles
+
+### 2.1 Dossier demandé vs artefacts réellement présents
+
+Le chemin demandé `RAPPORT-VESUVIUS/output_logs_vesuvius/v2-outlput-logs--nx46-vesuvius-core-kaggle-ready` n’existe pas dans ce dépôt local.
+
+Artefacts effectivement présents:
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/results.zip`
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/RkF4XakI.txt`
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/UJxLRsEE.txt`
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/nx46-vesuvius-challenge-surface-detection.ipynb`
+
+### 2.2 Ce que montre `results.zip` (preuve technique)
+
+Après extraction, `state.json` montre bien un pipeline déclaré actif mais **sans traitement réel**:
+- `active_neurons: 0`
+- `total_allocations: 0`
+- `total_pixels_processed: 0`
+- `train_fragments: []`
+- `test_fragments: []`
+- `submission_path: null`
+
+Le `forensic_ultra.log` contient seulement:
+- démarrage (`SYSTEM_STARTUP_L0_SUCCESS`)
+- fin (`SYSTEM_LOADED_100_PERCENT`)
+
+Aucune ligne intermédiaire de train/infer, ce qui confirme un parcours « vide ».
+
+---
+
+## 3) Pourquoi tout est à zéro — explication simple et exacte
+
+## Cause principale A — Mauvais contrat de dataset (format attendu ≠ format réel)
+
+Le notebook de référence qui fonctionne (`nx46-vesuvius-challenge-surface-detection.ipynb`) est explicitement orienté:
+- racine: `/kaggle/input/competitions/vesuvius-challenge-surface-detection`
+- entrées: `test_images/*.tif`
+- sortie: `submission.zip`
+
+Donc il cherche **des fichiers TIFF dans `test_images`** et échoue immédiatement si ce dossier n’existe pas.
+
+Le core NX46 compact qui a produit `results.zip` (ancien `nx46_vesuvius_core_kaggle_ready.py`) cherche surtout:
+- `train/<fragment>/surface_volume`
+- `test/<fragment>/surface_volume`
+
+et, s’il ne trouve rien, il ne plante pas immédiatement: il termine avec état « 100% offline » mais zéro activité.
+
+### Traduction non technique
+
+Le notebook « historique » ouvre la bonne porte (dataset compétition `test_images`).
+Le core compact ouvrait une autre porte (`train/test fragment_dirs`).
+Comme cette porte ne contenait rien dans l’exécution concernée, le moteur a démarré puis s’est arrêté sans matière à traiter.
+
+## Cause principale B — Signal de réussite trompeur
+
+`status = "100%_OFFLINE_ACTIVATED"` décrit uniquement l’état du runtime (mode offline actif), pas la réussite du traitement data.
+
+Donc « 100% » ici ne veut **pas** dire:
+- 100% des fichiers traités,
+- 100% de soumission générée,
+- 100% du pipeline scientifique validé.
+
+## Cause principale C — Divergence d’architecture entre références et adaptation
+
+Le notebook de référence est un pipeline compétition « strict »:
+- fail-fast si `test_images` absent,
+- packaging `submission.zip` exact,
+- logs de fin `EXEC_COMPLETE` + `READY: /kaggle/working/submission.zip`.
+
+Le core compact historique a simplifié et changé le contrat d’entrées/sorties, ce qui a cassé la compatibilité opérationnelle attendue.
+
+---
+
+## 4) Pourquoi les notebooks de référence avaient déjà les solutions
+
+Parce qu’ils incluent explicitement les garde-fous manquants dans le core compact initial:
+
+1. **Chemin racine compétition exact**
+   - `/kaggle/input/competitions/vesuvius-challenge-surface-detection`
+2. **Validation stricte des entrées**
+   - exception immédiate si `test_images` n’existe pas
+3. **Contrat de sortie stable compétition**
+   - `submission.zip` avec `.tif` nommés comme les entrées test
+4. **Preuve d’exécution terminée**
+   - événements `EXEC_COMPLETE` et `READY` affichés
+
+En clair: les réponses existaient, mais elles n’ont pas été totalement réintégrées de manière cohérente lors du passage au core compact.
+
+---
+
+## 5) Écart Avant / Après (pédagogique)
+
+## Avant (run qui finit à zéro)
+
+- Le moteur s’initialise.
+- Il cherche des structures de dossiers non alignées avec ce run Kaggle.
+- Il ne trouve aucun item train/test.
+- Il termine quand même « proprement » avec métriques nulles.
+
+## Après attendu (run correct)
+
+- Le moteur détecte automatiquement le bon layout (`test_images` ou `fragment_dirs`).
+- Si aucun test input: erreur explicite avec liste des chemins vérifiés.
+- Si inputs présents: allocations, inférence, merkle, métriques > 0.
+- `submission.zip` et éventuellement `submission.csv` produits.
+- Validation explicite des membres zip (missing/extra).
+
+---
+
+## 6) Suggestions de correction (priorisées)
+
+## P0 — Stopper les faux positifs de succès
+
+- Condition de fin stricte: si `len(test_items)==0`, lever une erreur bloquante explicite.
+- Ne jamais publier `status=100%` avec `total_pixels_processed==0` sans flag d’échec associé.
+
+## P0 — Verrouiller le contrat d’entrée Kaggle
+
+- Auto-discovery des racines `vesuvius` (input standard + competitions).
+- Journaliser `configured_data_root`, `effective_data_root`, `discovery_attempts`.
+
+## P0 — Garder le contrat de sortie compétition
+
+- Générer `submission.zip` en priorité pour Vesuvius competition.
+- Vérifier strictement que les noms `.tif` du zip correspondent aux fichiers test.
+
+## P1 — Séparer « état runtime » et « état métier »
+
+- `runtime_status`: offline/online
+- `pipeline_status`: success/failed/no_input
+
+Cela évite la confusion « 100% activé » vs « 0 pixel traité ».
+
+## P1 — Ajouter des invariants de sécurité
+
+- Invariant 1: `total_pixels_processed > 0` quand `pipeline_status=success`
+- Invariant 2: `submission_zip != null` quand des tests existent
+- Invariant 3: `zip_members_validated == True` en mode compétition strict
+
+## P2 — Audit pédagogique reproductible
+
+- Générer un mini rapport final auto (json/md) avec:
+  - root choisi,
+  - nb items train/test,
+  - nb fichiers submission,
+  - verdict.
+
+---
+
+## 7) Réponse directe à ta question « pourquoi c’est encore à zéro ? »
+
+Parce que l’exécution qui a produit ces logs n’a trouvé **aucune entrée test** dans le layout recherché par cette version du script, et a terminé sans bloquer (design permissif), en marquant seulement l’activation offline mais sans traitement data réel.
+
+Donc ce n’est pas un « moteur qui a calculé faux » ; c’est surtout un « moteur qui n’a rien reçu à calculer » à cause d’un mismatch d’architecture d’entrées.
+
+---
+
+## 8) Validation des preuves utilisées
+
+Ce diagnostic s’appuie sur:
+- les logs extraits de `results.zip` (state + forensic + metrics),
+- le notebook de référence Vesuvius qui montre le contrat exact `test_images` + `submission.zip` + fail-fast,
+- le script compact NX46 historique qui recherchait principalement `train/test` fragments.
+
+---
+
+## 9) Conclusion opérationnelle
+
+Le problème « tout à zéro » est **structurel (contrat d’entrée/sortie et logique de garde)**, pas un simple bug numérique.
+
+La résolution correcte consiste à:
+1. réaligner strictement la découverte de dataset avec les layouts Kaggle réels,
+2. empêcher toute fin “success-like” sans data traitée,
+3. imposer les invariants de sortie compétition.
+
+C’est exactement ce qu’il faut verrouiller pour éviter de revivre ce scénario dans les prochains runs.

--- a/RAPPORT-VESUVIUS/RAPPORT_REINTEGRATION_NX46_V3_FROM_NOTEBOOK_1771124473890.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_REINTEGRATION_NX46_V3_FROM_NOTEBOOK_1771124473890.md
@@ -1,0 +1,112 @@
+# RAPPORT DE RÉINTÉGRATION NX46 V3
+## Source principale réintégrée: `nx46-vesuvius-challenge-surface-detection_1771124473890.ipynb`
+
+## 1. Objectif
+
+Ce rapport documente exactement ce qui a été repris des versions de référence (notebook validé), pourquoi c'était nécessaire, et comment cela a été réintégré dans `nx46-vesuvius-core-kaggle-ready-v3.py`.
+
+## 2. Problème constaté avant V3
+
+Les runs précédents pouvaient finir avec:
+- `layout_detected = empty`
+- `total_pixels_processed = 0`
+- pas de `submission.zip`
+
+Cause principale: divergence entre la détection d'entrées du core compact et les patterns réels Kaggle déjà validés dans le notebook de référence.
+
+## 3. Éléments réintégrés depuis le notebook 1771124473890
+
+### 3.1 Bootstrap offline des dépendances (copie de méthode validée)
+
+Réintégration de la stratégie déjà utilisée dans le notebook:
+- `install_offline(package_name)`
+- priorité au path: `/kaggle/input/datasets/ndarray2000/nx47-dependencies`
+- fallback: `/kaggle/input/nx47-dependencies`
+- bootstrap ordonné: numpy, imagecodecs, tifffile.
+
+Bénéfice:
+- cohérence avec les exécutions Kaggle offline déjà validées,
+- suppression des écarts de comportement liés à l'environnement.
+
+### 3.2 Lecture TIFF LZW robuste (même logique de sécurité)
+
+Réintégration de:
+- `ensure_imagecodecs()`
+- `read_tiff_lzw_safe()` avec retry après installation codec,
+- fallback Pillow si nécessaire.
+
+Bénéfice:
+- évite l'échec classique "requires imagecodecs" dans les volumes TIFF compression LZW.
+
+### 3.3 Détection dataset alignée sur les versions qui marchent
+
+Réintégration des patterns de découverte réels:
+1. `competition_test_images` (`test_images/*.tif`) — prioritaire
+2. `fragment_dirs` (`train/<id>/surface_volume` et `test/<id>/surface_volume`)
+3. `legacy_tif_files` (`train_images/*.tif` + `test_images/*.tif`)
+
++ auto-discovery multi-roots Kaggle (incluant `competitions/vesuvius-challenge-surface-detection`).
+
+Bénéfice:
+- évite les runs "empty" quand la racine par défaut ne correspond pas au dataset monté.
+
+### 3.4 Inventaire complet des fichiers dataset (méthode d’audit)
+
+Ajout d’un inventaire automatique:
+- nombre total d’assets,
+- stats par extension,
+- liste des dossiers détectés.
+
+Sortie dédiée:
+- `dataset_discovery_inventory.json`
+
+Bénéfice:
+- preuve forensic immédiate de ce qui est réellement visible par le kernel.
+
+### 3.5 Sortie compétition stricte
+
+Réintégration d’un contrat strict:
+- génération `submission.zip` avec `.tif` LZW,
+- validation stricte des membres zip contre les fichiers test attendus,
+- fail-fast si mismatch en mode strict.
+
++ compatibilité `submission.csv` quand `sample_submission.csv` existe.
+
+### 3.6 Logs de preuve d’exécution
+
+Réintégration des signaux exploitables:
+- `EXEC_COMPLETE`
+- affichage final `READY: ...`
+- logs forensics multi-fichiers
+- exports `RkF4XakI.txt` et `UJxLRsEE.txt`.
+
+## 4. Pourquoi ces corrections règlent le "tout à zéro"
+
+Parce que V3:
+1. n'utilise plus un seul schéma de dossiers,
+2. cherche explicitement les racines Kaggle réellement utilisées,
+3. échoue clairement si aucune entrée test réelle n’est trouvée,
+4. valide la sortie finale compétition au lieu de conclure silencieusement.
+
+Donc on passe d’un pipeline permissif silencieux à un pipeline strict, traçable et compatible compétition.
+
+## 5. Livrables V3
+
+- Script: `RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v3.py`
+- Rapport: `RAPPORT-VESUVIUS/RAPPORT_REINTEGRATION_NX46_V3_FROM_NOTEBOOK_1771124473890.md`
+
+## 6. Recommandation d’exécution Kaggle
+
+1. Monter le dataset compétition Vesuvius.
+2. Lancer le script V3.
+3. Vérifier dans `work_root/logs`:
+   - `dataset_discovery_inventory.json`
+   - `forensic_ultra.log`
+   - `state.json`
+4. Vérifier présence de:
+   - `submission.zip`
+   - `READY: ...` dans la sortie standard.
+
+## 7. Conclusion
+
+La V3 remet le pipeline sur la méthode des versions de référence (celles qui fonctionnaient déjà), au lieu de réinventer un comportement partiellement incompatible.

--- a/RAPPORT-VESUVIUS/output_logs_vesuvius/RAPPORT_BLOCAGE_RECUPERATION_V3_LOGS.md
+++ b/RAPPORT-VESUVIUS/output_logs_vesuvius/RAPPORT_BLOCAGE_RECUPERATION_V3_LOGS.md
@@ -1,0 +1,40 @@
+# Rapport de blocage — récupération des logs V3 demandés
+
+## Contexte
+Tu as demandé une reprise complète à partir de:
+`RAPPORT-VESUVIUS/output_logs_vesuvius/v3-outlput-logs--nx46-vesuvius-core-kaggle-ready`
+
+## Vérification effectuée
+Dans ce snapshot local du dépôt, ce dossier **n'existe pas**.
+
+Dossiers trouvés sous `RAPPORT-VESUVIUS/output_logs_vesuvius`:
+- `v2-outlput-logs--nx46-vesuvius-core-kaggle-ready`
+
+Aucun dossier `v3-outlput-logs--...` ni variante `v3-output-logs--...` détecté.
+
+## Impact
+Sans les artefacts V3 réels (state/logs/metrics/submission), je ne peux pas produire une analyse « ligne par ligne des nouveaux résultats V3 » fidèle et vérifiable.
+
+## Ce que j'ai fait pour aller au maximum malgré le blocage
+1. Revalidation de l'arborescence locale et recherche exhaustive de dossiers correspondants.
+2. Vérification du contenu versionné actuel: seules traces disponibles = v2 + fichiers génériques dans `output_logs_vesuvius`.
+3. Préparation d'un point de reprise immédiat: dès que le dossier V3 est présent, je peux lancer l'audit complet demandé.
+
+## Prochaine action exacte (dès disponibilité)
+Dès que `v3-outlput-logs--nx46-vesuvius-core-kaggle-ready` est push dans ce repo (ou son nom exact confirmé), je ferai:
+1. extraction (si zip),
+2. lecture détaillée de chaque fichier,
+3. cours pédagogique complet (c’est-à-dire / donc / conclusion),
+4. anomalies, patterns, auto-critique,
+5. comparaison AGNN vs CNN,
+6. synthèse finale avec questions expert.
+
+## Hypothèse probable
+Le dossier V3 existe sur un autre état GitHub mais n’est pas encore dans ce checkout local (ou nom de dossier différent).
+
+## Vérification nommage conseillée
+Merci de confirmer exactement l'un des chemins suivants (copier-coller exact):
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/v3-outlput-logs--nx46-vesuvius-core-kaggle-ready`
+- `RAPPORT-VESUVIUS/output_logs_vesuvius/v3-output-logs--nx46-vesuvius-core-kaggle-ready`
+
+Dès réception, j’exécute l’audit V3 complet sans repartir de v2.

--- a/RAPPORT-VESUVIUS/output_logs_vesuvius/v2-outlput-logs--nx46-vesuvius-core-kaggle-ready/RAPPORT_AUDIT_COMPLET_COURS_V3_EXECUTION.md
+++ b/RAPPORT-VESUVIUS/output_logs_vesuvius/v2-outlput-logs--nx46-vesuvius-core-kaggle-ready/RAPPORT_AUDIT_COMPLET_COURS_V3_EXECUTION.md
@@ -1,0 +1,279 @@
+# Rapport d'audit complet (cours pédagogique) — Exécution NX46/V3
+
+## 0) Important avant de commencer
+
+Le dossier demandé pour les « derniers résultats v3 GitHub » n'existe pas localement sous le nom exact `v3-outlput-logs--nx46-vesuvius-core-kaggle-ready`.
+
+Pour ne pas bloquer ton audit, j’ai:
+1. extrait les artefacts réellement disponibles (`results.zip`) dans:
+   `RAPPORT-VESUVIUS/output_logs_vesuvius/v2-outlput-logs--nx46-vesuvius-core-kaggle-ready/extracted_results`
+2. comparé ces résultats avec le notebook de référence qui, lui, montre une exécution aboutie (`EXEC_COMPLETE` + `READY`).
+
+---
+
+## 1) Inventaire des fichiers analysés
+
+## A. Fichiers logs extraits
+- `extracted_results/nx46_vesuvius/logs/state.json`
+- `extracted_results/nx46_vesuvius/logs/forensic_ultra.log`
+- `extracted_results/nx46_vesuvius/logs/metrics.csv`
+
+## B. Fichiers de console Kaggle
+- `RkF4XakI.txt`
+- `UJxLRsEE.txt`
+
+## C. Fichier de référence (exécution validée)
+- `nx46-vesuvius-challenge-surface-detection.ipynb`
+
+---
+
+## 2) Lecture « ligne par ligne » des résultats réels
+
+## 2.1 `state.json` (état final machine)
+
+Valeurs observées:
+- status = `100%_OFFLINE_ACTIVATED`
+- `active_neurons = 0`
+- `total_allocations = 0`
+- `total_pixels_processed = 0`
+- `total_ink_pixels = 0`
+- `ink_ratio = 0.0`
+- `qi_index_real = 0.0`
+- `merkle_root = null`
+- `train_fragments = []`
+- `test_fragments = []`
+- `submission_path = null`
+
+### C’est-à-dire ?
+Le programme s’est lancé et arrêté proprement, mais n’a rien traité.
+
+### Donc ?
+Ce n’est pas une erreur de calcul de neurone; c’est une absence d’entrées détectées dans ce run.
+
+### Conclusion
+Le pipeline est « vivant » côté runtime, mais « vide » côté données.
+
+---
+
+## 2.2 `forensic_ultra.log` (journal d’événements)
+
+Seulement deux lignes:
+1. `SYSTEM_STARTUP_L0_SUCCESS`
+2. `SYSTEM_LOADED_100_PERCENT`
+
+### C’est-à-dire ?
+Il manque tous les événements intermédiaires (allocation, train, infer, packaging).
+
+### Donc ?
+Aucun lot de données n’a traversé les étapes métier.
+
+### Conclusion
+Workflow court-circuité par non-détection d’inputs.
+
+---
+
+## 2.3 `metrics.csv` (métriques par fragment)
+
+On observe uniquement l’en-tête, sans aucune ligne data.
+
+### C’est-à-dire ?
+Aucun fragment/test n’a généré de métriques calculées.
+
+### Donc ?
+Pas d’inférence, pas de masque, pas de soumission.
+
+### Conclusion
+Le cœur algorithmique n’a pas été exercé sur données réelles pendant ce run.
+
+---
+
+## 2.4 `RkF4XakI.txt` / `UJxLRsEE.txt` (sortie notebook)
+
+Les deux fichiers montrent:
+- le même JSON « tout à zéro »
+- des warnings debugger/nbconvert autour
+- aucun signal métier de type `EXEC_COMPLETE` utile à la soumission
+
+### C’est-à-dire ?
+Ces fichiers capturent surtout la fin de notebook + conversion, pas une production de soumission valide.
+
+### Donc ?
+Ils confirment l’état « pipeline lancé mais sans traitement data ».
+
+### Conclusion
+Double preuve de l’anomalie « 100% offline mais 0 traitement ».
+
+---
+
+## 3) Comparaison avec la version de référence qui fonctionne
+
+Le notebook de référence valide montre explicitement:
+- format input compétition `test_images/*.tif`
+- sortie `submission.zip`
+- garde-fou fail-fast si `test_images` absent
+- preuve de fin: `EXEC_COMPLETE` puis `READY: /kaggle/working/submission.zip`
+
+### C’est-à-dire ?
+La version de référence possède un contrat I/O compétition strict.
+
+### Donc ?
+Quand ce contrat est respecté, on observe des métriques slice par slice et une soumission concrète.
+
+### Conclusion
+Le problème principal est l’alignement de détection/format, pas une impossibilité mathématique du moteur.
+
+---
+
+## 4) Qualité pixel et apprentissage: ce qu’on peut conclure (et ce qu’on ne peut pas)
+
+## 4.1 Qualité pixel
+
+Dans ce run « tout à zéro », impossible d’évaluer:
+- distribution d’intensité réelle,
+- bruit local,
+- qualité de segmentation.
+
+Pourquoi ? Parce qu’aucune image n’a été effectivement traitée (0 pixel).
+
+## 4.2 Processus d’apprentissage
+
+Le design NX46 prévu est:
+- normalisation stack
+- projection énergie d’encre
+- estimation seuil (train)
+- inférence masque (test)
+
+Mais dans ce run, ces étapes n’ont pas reçu d’inputs.
+
+## 4.3 Processus de raisonnement
+
+Raisonnement forensique minimal validé:
+1. si `train/test items == 0`
+2. alors pas de métriques par fragment
+3. alors état final peut rester à zéro même avec status runtime actif
+
+---
+
+## 5) « Découvertes inconnues », axiomes, lemmes, Lean4, théorie
+
+## 5.1 Résultat honnête basé sur les fichiers
+
+Aucune trace explicite de:
+- axiome formel,
+- lemme formel,
+- theorem proving Lean4,
+- démonstration mathématique nouvelle,
+- découverte « inconnue de la littérature »
+
+n’apparaît dans les logs extraits.
+
+## 5.2 Pourquoi cette réponse est la bonne
+
+Les artefacts observés sont des logs d’exécution ingénierie (pipeline), pas un papier scientifique ni une preuve formelle.
+
+### C’est-à-dire ?
+On ne peut pas prouver une découverte scientifique nouvelle avec ces seuls fichiers.
+
+### Donc ?
+Toute affirmation « nouvelle découverte littérature » serait non fiable ici.
+
+### Conclusion
+Niveau preuve actuel = technique/logiciel, pas découverte fondamentale validée.
+
+---
+
+## 6) Anomalies, patterns, auto-critique
+
+## 6.1 Anomalies détectées
+
+1. **Contradiction sémantique**
+   - status dit « activé 100% », mais activité réelle = 0.
+
+2. **Absence de garde métier bloquante**
+   - exécution terminée sans pipeline data effectif.
+
+3. **Artefacts de sortie incomplets**
+   - pas de `submission.zip` validé dans ce run.
+
+## 6.2 Pattern
+
+Pattern d’échec reproductible:
+- dataset non détecté
+- logs startup/shutdown uniquement
+- métriques vides
+- état final nul
+
+## 6.3 Auto-critique technique
+
+Ce type de pipeline doit séparer clairement:
+- statut runtime (script lancé)
+- statut métier (données traitées + soumission validée)
+
+Sinon on crée un faux sentiment de réussite.
+
+---
+
+## 7) Comparaison NX46/AGNN vs CNN (niveau pédagogique)
+
+## 7.1 AGNN/NX46 (ici)
+- logique orientée règles énergétiques + seuil + forensics
+- auditabilité forte (merkle/bits/logs)
+- dépend fortement du contrat dataset bien détecté
+
+## 7.2 CNN (classique)
+- apprentissage bout-en-bout par backprop
+- nécessite dataset/train loop robuste
+- souvent plus performant si entraîné massivement
+- moins explicable sans instrumentation dédiée
+
+## 7.3 Résumé comparaison
+- **NX46**: explicable/auditable, sensible au workflow I/O strict
+- **CNN**: puissant statistiquement, plus opaque sans outils XAI
+
+---
+
+## 8) Graphique processus A→Z (texte)
+
+```mermaid
+flowchart TD
+A[Bootstrap offline deps] --> B[Discover dataset roots/layout]
+B -->|No test items| C[Fail-fast NO_TEST_INPUTS_FOUND]
+B -->|Test items found| D[Load TIFF LZW]
+D --> E[Normalize + energy projection]
+E --> F[Train threshold if labels]
+F --> G[Infer masks]
+G --> H[Write submission.zip / csv]
+H --> I[Validate zip members]
+I --> J[Write forensic logs + state]
+J --> K[EXEC_COMPLETE + READY]
+```
+
+---
+
+## 9) Questions expert à te poser (vérification de compréhension)
+
+1. Si `total_pixels_processed = 0`, puis-je croire un score modèle ?
+2. Quelle est la différence entre « runtime actif » et « pipeline réussi » ?
+3. Le dossier racine contient-il réellement `test_images` ou `test/<fragment>/surface_volume` ?
+4. Le zip final contient-il exactement les `.tif` attendus, sans manque ni extra ?
+5. Les logs montrent-ils des événements intermédiaires (train/infer) ou seulement start/end ?
+
+---
+
+## 10) Suggestions concrètes immédiates
+
+1. Exécuter la v3 qui inclut détection multi-layout + bootstrap deps offline.
+2. Vérifier `dataset_discovery_inventory.json` en premier.
+3. Exiger l’invariant suivant en CI:
+   - `total_pixels_processed > 0`
+   - `submission_zip != null`
+   - `zip_members_validated == true`
+4. Refuser tout run qui publie "success" si ces invariants échouent.
+
+---
+
+## 11) Résumé final ultra-court
+
+- Les résultats réels extraits montrent un run **sans données traitées**.
+- Le notebook de référence prouve que le pipeline peut réussir quand le format dataset est correctement détecté.
+- La clé est le verrouillage du contrat I/O et des invariants de validation métier.

--- a/RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v2.py
+++ b/RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v2.py
@@ -1,0 +1,592 @@
+"""NX-46 Vesuvius core (Kaggle-ready v2, offline-first).
+
+Objectifs v2:
+- Corriger la non-détection de données (train/test fragments VS train_images/test_images).
+- Garder un pipeline 100% offline exécutable dans Kaggle.
+- Produire les artefacts de logs attendus + état final explicite.
+- Générer submission.csv (format tabulaire) ET submission.zip (format TIFF par id) selon les entrées.
+- Valider strictement la conformité des membres du zip aux fichiers test attendus.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import time
+import zipfile
+from dataclasses import dataclass
+from hashlib import sha512
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+try:
+    import tifffile  # type: ignore
+except Exception:  # pragma: no cover - fallback en environnement réduit
+    tifffile = None
+
+try:
+    import imageio.v3 as iio
+except Exception:  # pragma: no cover - fallback en environnement réduit
+    iio = None
+
+
+@dataclass
+class NX46Config:
+    data_root: str = "/kaggle/input/vesuvius-challenge-ink-detection"
+    work_root: str = "/kaggle/working/nx46_vesuvius"
+    seed: int = 46
+    bit_capture_bytes: int = 256
+    threshold_quantile: float = 0.985
+    slab_min_neurons: int = 128
+    auto_discover_data_root: bool = True
+
+
+class ProgressRoadmap:
+    def __init__(self) -> None:
+        self.steps: Dict[str, float] = {
+            "audit_discovery": 0.0,
+            "train_thresholds": 0.0,
+            "infer_predictions": 0.0,
+            "package_submission": 0.0,
+            "finalize_forensics": 0.0,
+        }
+
+    def update(self, step: str, pct: float) -> None:
+        self.steps[step] = max(0.0, min(100.0, float(pct)))
+        print(f"[ROADMAP] {step}: {self.steps[step]:.1f}%")
+
+    def as_dict(self) -> Dict[str, float]:
+        return dict(self.steps)
+
+
+class HFBL360Logger:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+        self.log_path = root / "forensic_ultra.log"
+        self.core_log = root / "nx-46-vesuvius-core.log"
+        self.kaggle_log = root / "nx46-vesuvius-core-kaggle-ready.log"
+        self.csv_path = root / "metrics.csv"
+        self.state_path = root / "state.json"
+        self.bit_path = root / "bit_capture.log"
+        self.merkle_path = root / "merkle_chain.log"
+
+        with self.csv_path.open("w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(
+                [
+                    "timestamp_ns",
+                    "phase",
+                    "fragment",
+                    "neurons_active",
+                    "cpu_ns",
+                    "ink_pixels",
+                    "total_pixels",
+                    "ink_ratio",
+                    "merkle_prefix",
+                ]
+            )
+
+    def _append_all_logs(self, text: str) -> None:
+        for p in (self.log_path, self.core_log, self.kaggle_log):
+            with p.open("a", encoding="utf-8") as f:
+                f.write(text + "\n")
+
+    def log_event(self, message: str) -> None:
+        self._append_all_logs(f"{time.time_ns()} | {message}")
+
+    def log_bits(self, fragment: str, payload: bytes) -> None:
+        bit_string = "".join(f"{b:08b}" for b in payload)
+        with self.bit_path.open("a", encoding="utf-8") as f:
+            f.write(f"{time.time_ns()} | {fragment} | {bit_string}\n")
+
+    def log_merkle(self, fragment: str, digest: str) -> None:
+        with self.merkle_path.open("a", encoding="utf-8") as f:
+            f.write(f"{time.time_ns()} | {fragment} | {digest}\n")
+
+    def log_metrics(
+        self,
+        *,
+        phase: str,
+        fragment: str,
+        neurons_active: int,
+        cpu_ns: int,
+        ink_pixels: int,
+        total_pixels: int,
+        merkle_prefix: str,
+    ) -> None:
+        ratio = (ink_pixels / total_pixels) if total_pixels else 0.0
+        with self.csv_path.open("a", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(
+                [
+                    time.time_ns(),
+                    phase,
+                    fragment,
+                    neurons_active,
+                    cpu_ns,
+                    ink_pixels,
+                    total_pixels,
+                    f"{ratio:.8f}",
+                    merkle_prefix,
+                ]
+            )
+
+    def write_state(self, state: Dict[str, object]) -> None:
+        state = dict(state)
+        state["timestamp_ns"] = time.time_ns()
+        with self.state_path.open("w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2, ensure_ascii=False)
+
+
+class NX46AGNNVesuvius:
+    def __init__(self, cfg: NX46Config) -> None:
+        self.cfg = cfg
+        self.rng = np.random.default_rng(cfg.seed)
+        self.logger = HFBL360Logger(Path(cfg.work_root) / "logs")
+        self.neurons_active = 0
+        self.total_allocations = 0
+        self.total_pixels_processed = 0
+        self.total_ink_pixels = 0
+        self.merkle_chain: List[str] = []
+        self.global_cpu_start_ns = time.process_time_ns()
+        self.logger.log_event("SYSTEM_STARTUP_L0_SUCCESS")
+
+    def slab_allocate(self, tensor: np.ndarray, phase: str) -> int:
+        variance = float(np.var(tensor, dtype=np.float64))
+        entropy_proxy = float(np.mean(np.abs(np.gradient(tensor.astype(np.float32), axis=-1))))
+        required = int(
+            self.cfg.slab_min_neurons
+            + (tensor.size // 512)
+            + variance * 1500.0
+            + entropy_proxy * 900.0
+        )
+        self.neurons_active = max(self.cfg.slab_min_neurons, required)
+        self.total_allocations += 1
+        self.logger.log_event(
+            f"SLAB_ALLOCATION phase={phase} neurons={self.neurons_active} variance={variance:.8f} entropy_proxy={entropy_proxy:.8f}"
+        )
+        return self.neurons_active
+
+    def _track_bits(self, fragment: str, arr: np.ndarray) -> None:
+        self.logger.log_bits(fragment, arr.tobytes()[: self.cfg.bit_capture_bytes])
+
+    def _merkle_sign(self, fragment: str, arr: np.ndarray) -> str:
+        prev = self.merkle_chain[-1] if self.merkle_chain else "GENESIS"
+        digest = sha512(prev.encode("utf-8") + arr.tobytes()).hexdigest()
+        self.merkle_chain.append(digest)
+        self.logger.log_merkle(fragment, digest)
+        return digest
+
+    @staticmethod
+    def _normalize_stack(stack: np.ndarray) -> np.ndarray:
+        x = stack.astype(np.float32)
+        mn, mx = float(x.min()), float(x.max())
+        if mx <= mn:
+            return np.zeros_like(x, dtype=np.float32)
+        return (x - mn) / (mx - mn)
+
+    @staticmethod
+    def _ink_energy_projection(stack: np.ndarray) -> np.ndarray:
+        grad_z = np.abs(np.diff(stack, axis=0, prepend=stack[:1]))
+        grad_y = np.abs(np.diff(stack, axis=1, prepend=stack[:, :1, :]))
+        grad_x = np.abs(np.diff(stack, axis=2, prepend=stack[:, :, :1]))
+        return np.mean(0.45 * grad_z + 0.30 * grad_y + 0.25 * grad_x, axis=0)
+
+    def train_threshold(self, stack: np.ndarray, labels: np.ndarray, fragment: str) -> float:
+        start = time.process_time_ns()
+        self.slab_allocate(stack, phase="train")
+        self._track_bits(fragment, stack)
+
+        score = self._ink_energy_projection(self._normalize_stack(stack))
+        pos = score[labels > 0]
+        neg = score[labels <= 0]
+
+        if pos.size and neg.size:
+            threshold = float(0.5 * (float(np.median(pos)) + float(np.median(neg))))
+        elif pos.size:
+            threshold = float(np.quantile(pos, 0.50))
+        else:
+            threshold = float(np.quantile(score, self.cfg.threshold_quantile))
+
+        pred = (score >= threshold).astype(np.uint8)
+        digest = self._merkle_sign(fragment, score)
+        cpu_ns = time.process_time_ns() - start
+
+        ink_pixels = int(pred.sum())
+        total_pixels = int(pred.size)
+        self.total_ink_pixels += ink_pixels
+        self.total_pixels_processed += total_pixels
+
+        self.logger.log_metrics(
+            phase="train",
+            fragment=fragment,
+            neurons_active=self.neurons_active,
+            cpu_ns=cpu_ns,
+            ink_pixels=ink_pixels,
+            total_pixels=total_pixels,
+            merkle_prefix=digest[:16],
+        )
+        self.logger.log_event(f"TRAIN_DONE fragment={fragment} threshold={threshold:.8f}")
+        return threshold
+
+    def infer_mask(self, stack: np.ndarray, threshold: float, fragment: str) -> np.ndarray:
+        start = time.process_time_ns()
+        self.slab_allocate(stack, phase="infer")
+        self._track_bits(fragment, stack)
+
+        score = self._ink_energy_projection(self._normalize_stack(stack))
+        pred = (score >= threshold).astype(np.uint8)
+        digest = self._merkle_sign(fragment, pred)
+        cpu_ns = time.process_time_ns() - start
+
+        ink_pixels = int(pred.sum())
+        total_pixels = int(pred.size)
+        self.total_ink_pixels += ink_pixels
+        self.total_pixels_processed += total_pixels
+
+        self.logger.log_metrics(
+            phase="infer",
+            fragment=fragment,
+            neurons_active=self.neurons_active,
+            cpu_ns=cpu_ns,
+            ink_pixels=ink_pixels,
+            total_pixels=total_pixels,
+            merkle_prefix=digest[:16],
+        )
+        return pred
+
+    def finalize(self, extra: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+        cpu_total_ns = time.process_time_ns() - self.global_cpu_start_ns
+        qi_index = self.total_pixels_processed / max(cpu_total_ns, 1)
+        state = {
+            "status": "100%_OFFLINE_ACTIVATED",
+            "active_neurons": self.neurons_active,
+            "total_allocations": self.total_allocations,
+            "total_pixels_processed": self.total_pixels_processed,
+            "total_ink_pixels": self.total_ink_pixels,
+            "ink_ratio": self.total_ink_pixels / self.total_pixels_processed if self.total_pixels_processed else 0.0,
+            "qi_index_real": qi_index,
+            "cpu_total_ns": cpu_total_ns,
+            "merkle_root": self.merkle_chain[-1] if self.merkle_chain else None,
+        }
+        if extra:
+            state.update(extra)
+        self.logger.write_state(state)
+        self.logger.log_event("SYSTEM_LOADED_100_PERCENT")
+        return state
+
+
+def _read_tif(path: Path) -> np.ndarray:
+    if tifffile is not None:
+        arr = tifffile.imread(path)
+        return np.asarray(arr)
+    if iio is None:
+        raise RuntimeError("tifffile et imageio indisponibles: impossible de lire les TIFF.")
+    return np.asarray(iio.imread(str(path)))
+
+
+def _write_tif(path: Path, arr2d: np.ndarray) -> None:
+    arr2d = (arr2d > 0).astype(np.uint8) * 255
+    if tifffile is not None:
+        tifffile.imwrite(path, arr2d, compression="LZW")
+        return
+    if iio is None:
+        raise RuntimeError("tifffile et imageio indisponibles: impossible d'écrire les TIFF.")
+    iio.imwrite(str(path), arr2d)
+
+
+def _to_stack(raw: np.ndarray) -> np.ndarray:
+    a = np.asarray(raw)
+    if a.ndim == 2:
+        return a[None, :, :]
+    if a.ndim == 3:
+        return a
+    raise ValueError(f"Unsupported TIFF ndim={a.ndim}; attendu 2D ou 3D.")
+
+
+def _read_stack_from_fragment(fragment_dir: Path) -> np.ndarray:
+    volume_dir = fragment_dir / "surface_volume"
+    tif_files = sorted(volume_dir.glob("*.tif"))
+    if not tif_files:
+        raise FileNotFoundError(f"No TIFF slices found in {volume_dir}")
+    slices = [_to_stack(_read_tif(p))[0] for p in tif_files]
+    return np.stack(slices, axis=0)
+
+
+def _load_label_png(fragment_dir: Path) -> Optional[np.ndarray]:
+    p = fragment_dir / "inklabels.png"
+    if not p.exists() or iio is None:
+        return None
+    arr = np.asarray(iio.imread(str(p)))
+    if arr.ndim == 3:
+        arr = arr[..., 0]
+    return (arr > 0).astype(np.uint8)
+
+
+def _read_sample_submission_ids(sample_csv: Path) -> List[str]:
+    ids: List[str] = []
+    with sample_csv.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        cols = set(reader.fieldnames or [])
+        id_col = "Id" if "Id" in cols else ("id" if "id" in cols else None)
+        if id_col is None:
+            return ids
+        for row in reader:
+            v = str(row[id_col]).strip()
+            if v:
+                ids.append(v)
+    return ids
+
+
+def _discover_layout(root: Path) -> Tuple[str, List[Path], List[Path], List[Path]]:
+    train_fragment_dirs = sorted([p for p in (root / "train").glob("*") if p.is_dir()]) if (root / "train").exists() else []
+    test_fragment_dirs = sorted([p for p in (root / "test").glob("*") if p.is_dir()]) if (root / "test").exists() else []
+    train_image_tifs = sorted((root / "train_images").glob("*.tif")) if (root / "train_images").exists() else []
+    test_image_tifs = sorted((root / "test_images").glob("*.tif")) if (root / "test_images").exists() else []
+
+    if train_fragment_dirs or test_fragment_dirs:
+        return "fragments", train_fragment_dirs, test_fragment_dirs, []
+    if train_image_tifs or test_image_tifs:
+        return "images", train_image_tifs, test_image_tifs, []
+    return "empty", [], [], []
+
+
+def _iter_candidate_roots(primary_root: Path) -> List[Path]:
+    candidates: List[Path] = []
+
+    def add(path: Path) -> None:
+        if path not in candidates:
+            candidates.append(path)
+
+    add(primary_root)
+    add(Path("/kaggle/input/vesuvius-challenge-ink-detection"))
+    add(Path("/kaggle/input/vesuvius-challenge-surface-detection"))
+    add(Path("/kaggle/input/competitions/vesuvius-challenge-surface-detection"))
+
+    kaggle_input = Path("/kaggle/input")
+    if kaggle_input.exists():
+        for entry in sorted(kaggle_input.iterdir()):
+            if entry.is_dir() and "vesuvius" in entry.name.lower():
+                add(entry)
+
+    competitions = Path("/kaggle/input/competitions")
+    if competitions.exists():
+        for entry in sorted(competitions.iterdir()):
+            if entry.is_dir() and "vesuvius" in entry.name.lower():
+                add(entry)
+
+    return [p for p in candidates if p.exists()]
+
+
+def _resolve_data_root(primary_root: Path, auto_discover: bool) -> Tuple[Path, str, List[Dict[str, object]]]:
+    roots = _iter_candidate_roots(primary_root) if auto_discover else [primary_root]
+    attempts: List[Dict[str, object]] = []
+
+    for root in roots:
+        layout, train_items, test_items, _ = _discover_layout(root)
+        attempts.append(
+            {
+                "root": str(root),
+                "layout": layout,
+                "train_items": len(train_items),
+                "test_items": len(test_items),
+            }
+        )
+        if test_items:
+            return root, layout, attempts
+
+    return primary_root, "empty", attempts
+
+
+def _safe_resize_pair(stack: np.ndarray, labels: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    h = min(stack.shape[1], labels.shape[0])
+    w = min(stack.shape[2], labels.shape[1])
+    return stack[:, :h, :w], labels[:h, :w]
+
+
+def _write_submission_csv(out_path: Path, sample_csv: Path, predictions_by_id: Dict[str, np.ndarray]) -> Optional[str]:
+    ids = _read_sample_submission_ids(sample_csv)
+    if not ids:
+        return None
+
+    flat = np.concatenate([predictions_by_id[i].reshape(-1).astype(np.uint8) for i in sorted(predictions_by_id)])
+    n = min(len(ids), len(flat))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Id", "Predicted"])
+        for i in range(n):
+            writer.writerow([ids[i], int(flat[i])])
+    return str(out_path)
+
+
+def _write_submission_zip(
+    zip_path: Path,
+    masks_dir: Path,
+    predictions_by_id: Dict[str, np.ndarray],
+    expected_ids: Sequence[str],
+) -> Tuple[str, bool, List[str], List[str]]:
+    masks_dir.mkdir(parents=True, exist_ok=True)
+
+    written_files: List[str] = []
+    for fid, mask in predictions_by_id.items():
+        out_tif = masks_dir / f"{fid}.tif"
+        _write_tif(out_tif, mask)
+        written_files.append(out_tif.name)
+
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name in sorted(written_files):
+            zf.write(masks_dir / name, arcname=name)
+
+    got = sorted(written_files)
+    exp = sorted([f"{x}.tif" for x in expected_ids]) if expected_ids else got
+    ok = got == exp
+    missing = sorted(set(exp) - set(got))
+    extra = sorted(set(got) - set(exp))
+    return str(zip_path), ok, missing, extra
+
+
+def _emit_execution_txts(log_root: Path, payload: Dict[str, object]) -> None:
+    content = json.dumps(payload, indent=2, ensure_ascii=False)
+    for name in ("RkF4XakI.txt", "UJxLRsEE.txt"):
+        with (log_root / name).open("w", encoding="utf-8") as f:
+            f.write(content + "\n")
+
+
+def run_pipeline(cfg: NX46Config) -> Dict[str, object]:
+    configured_root = Path(cfg.data_root)
+    work = Path(cfg.work_root)
+    logs_root = work / "logs"
+    logs_root.mkdir(parents=True, exist_ok=True)
+
+    roadmap = ProgressRoadmap()
+    nx46 = NX46AGNNVesuvius(cfg)
+
+    root, layout, discovery_attempts = _resolve_data_root(configured_root, cfg.auto_discover_data_root)
+    layout, train_items, test_items, _ = _discover_layout(root)
+    roadmap.update("audit_discovery", 100.0)
+    nx46.logger.log_event(
+        f"LAYOUT_DETECTED={layout} train_items={len(train_items)} test_items={len(test_items)} root={root}"
+    )
+
+    if not test_items:
+        attempts_json = json.dumps(discovery_attempts, ensure_ascii=False)
+        nx46.logger.log_event(f"NO_TEST_INPUTS_FOUND attempts={attempts_json}")
+        raise RuntimeError(
+            "No test inputs found. Configure NX46_DATA_ROOT to the exact dataset path. "
+            f"Checked roots: {[a['root'] for a in discovery_attempts]}"
+        )
+
+    thresholds: List[float] = []
+
+    if layout == "fragments":
+        total_train = max(len(train_items), 1)
+        for idx, frag in enumerate(train_items, start=1):
+            pct = idx / total_train * 100.0
+            roadmap.update("train_thresholds", pct)
+            nx46.logger.log_event(f"PROGRESS train={idx}/{len(train_items)} ({pct:.1f}%)")
+
+            volume_dir = frag / "surface_volume"
+            if not volume_dir.exists():
+                continue
+            stack = _read_stack_from_fragment(frag)
+            labels = _load_label_png(frag)
+            if labels is None:
+                continue
+            if labels.shape != stack.shape[1:]:
+                stack, labels = _safe_resize_pair(stack, labels)
+            thresholds.append(nx46.train_threshold(stack, labels, frag.name))
+
+    threshold = float(np.median(np.asarray(thresholds, dtype=np.float32))) if thresholds else 0.5
+
+    predictions: Dict[str, np.ndarray] = {}
+
+    if layout == "fragments":
+        total_test = max(len(test_items), 1)
+        for idx, frag in enumerate(test_items, start=1):
+            pct = idx / total_test * 100.0
+            roadmap.update("infer_predictions", pct)
+            nx46.logger.log_event(f"PROGRESS test={idx}/{len(test_items)} ({pct:.1f}%)")
+            volume_dir = frag / "surface_volume"
+            if not volume_dir.exists():
+                continue
+            stack = _read_stack_from_fragment(frag)
+            predictions[frag.name] = nx46.infer_mask(stack, threshold, frag.name)
+
+    elif layout == "images":
+        total_test = max(len(test_items), 1)
+        for idx, tif_path in enumerate(test_items, start=1):
+            pct = idx / total_test * 100.0
+            roadmap.update("infer_predictions", pct)
+            nx46.logger.log_event(f"PROGRESS test_images={idx}/{len(test_items)} ({pct:.1f}%)")
+            stack = _to_stack(_read_tif(tif_path))
+            predictions[tif_path.stem] = nx46.infer_mask(stack, threshold, tif_path.stem)
+
+    roadmap.update("package_submission", 30.0)
+
+    sample_csv_candidates = [
+        root / "sample_submission.csv",
+        Path("/kaggle/input/vesuvius-challenge-ink-detection/sample_submission.csv"),
+        Path("/kaggle/input/vesuvius-challenge-surface-detection/sample_submission.csv"),
+        Path("/kaggle/input/competitions/vesuvius-challenge-surface-detection/sample_submission.csv"),
+    ]
+    sample_csv = next((p for p in sample_csv_candidates if p.exists()), None)
+
+    csv_submission_path: Optional[str] = None
+    expected_ids: List[str] = []
+    if sample_csv is not None:
+        expected_ids = _read_sample_submission_ids(sample_csv)
+        if predictions:
+            csv_submission_path = _write_submission_csv(work / "submission.csv", sample_csv, predictions)
+
+    roadmap.update("package_submission", 60.0)
+
+    zip_submission_path: Optional[str] = None
+    zip_ok: Optional[bool] = None
+    zip_missing: List[str] = []
+    zip_extra: List[str] = []
+    if predictions:
+        zip_submission_path, zip_ok, zip_missing, zip_extra = _write_submission_zip(
+            work / "submission.zip",
+            work / "submission_masks",
+            predictions,
+            expected_ids if expected_ids else sorted(predictions.keys()),
+        )
+
+    roadmap.update("package_submission", 100.0)
+    roadmap.update("finalize_forensics", 60.0)
+
+    result = nx46.finalize(
+        {
+            "layout_detected": layout,
+            "configured_data_root": str(configured_root),
+            "effective_data_root": str(root),
+            "discovery_attempts": discovery_attempts,
+            "train_items": [p.name for p in train_items],
+            "test_items": [p.name for p in test_items],
+            "train_threshold": threshold,
+            "submission_csv": csv_submission_path,
+            "submission_zip": zip_submission_path,
+            "zip_members_validated": zip_ok,
+            "zip_missing": zip_missing,
+            "zip_extra": zip_extra,
+            "roadmap_percent": roadmap.as_dict(),
+        }
+    )
+
+    roadmap.update("finalize_forensics", 100.0)
+    _emit_execution_txts(logs_root, result)
+    return result
+
+
+if __name__ == "__main__":
+    config = NX46Config(
+        data_root=os.environ.get("NX46_DATA_ROOT", NX46Config.data_root),
+        work_root=os.environ.get("NX46_WORK_ROOT", NX46Config.work_root),
+    )
+    final_state = run_pipeline(config)
+    print(json.dumps(final_state, indent=2, ensure_ascii=False))

--- a/RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v3.py
+++ b/RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v3.py
@@ -1,0 +1,687 @@
+"""NX-46 Vesuvius Kaggle-ready v3 (offline-first, forensic, strict competition compatibility).
+
+V3 goals:
+- Reuse the same dependency bootstrap strategy used by validated notebook versions.
+- Reuse robust dataset detection patterns (`test_images`, fragments, legacy layouts).
+- Produce strict Kaggle outputs (`submission.zip` + optional `submission.csv`) with forensic evidence.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib
+import json
+import os
+import subprocess
+import sys
+import time
+import zipfile
+from dataclasses import dataclass
+from hashlib import sha512
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+
+# --- Offline dependency bootstrap (ported from validated notebook patterns) ---
+def install_offline(package_name: str) -> None:
+    exact_wheel_dir = Path("/kaggle/input/datasets/ndarray2000/nx47-dependencies")
+    fallback_wheel_dir = Path("/kaggle/input/nx47-dependencies")
+
+    exact_wheels = {
+        "imagecodecs": exact_wheel_dir / "imagecodecs-2026.1.14-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "numpy": exact_wheel_dir / "numpy-2.4.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+        "tifffile": exact_wheel_dir / "tifffile-2026.1.28-py3-none-any.whl",
+    }
+
+    if package_name == "numpy" and importlib.util.find_spec("numpy") is not None:
+        return
+
+    if package_name in exact_wheels and exact_wheels[package_name].exists():
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "--no-index", str(exact_wheels[package_name])])
+            return
+        except subprocess.CalledProcessError:
+            pass
+
+    for wheel_dir in (exact_wheel_dir, fallback_wheel_dir):
+        if wheel_dir.exists():
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--no-index", f"--find-links={wheel_dir}", package_name]
+            )
+            return
+
+    raise RuntimeError(
+        f"Offline dependency directory not found for {package_name}. "
+        f"Checked: {exact_wheel_dir} and {fallback_wheel_dir}"
+    )
+
+
+def bootstrap_dependencies_fail_fast() -> None:
+    install_offline("numpy")
+    install_offline("imagecodecs")
+    install_offline("tifffile")
+
+
+bootstrap_dependencies_fail_fast()
+
+import numpy as np  # noqa: E402
+import tifffile  # noqa: E402
+import imageio.v3 as iio  # noqa: E402
+
+
+def ensure_imagecodecs() -> bool:
+    if importlib.util.find_spec("imagecodecs") is not None:
+        return True
+
+    try:
+        install_offline("imagecodecs")
+    except Exception:
+        return False
+
+    if importlib.util.find_spec("imagecodecs") is None:
+        return False
+
+    global tifffile
+    tifffile = importlib.reload(tifffile)
+    return True
+
+
+def read_tiff_lzw_safe(path: Path) -> np.ndarray:
+    try:
+        return np.asarray(tifffile.imread(path))
+    except ValueError as exc:
+        if "requires the 'imagecodecs' package" not in str(exc):
+            raise
+
+    ensure_imagecodecs()
+    try:
+        return np.asarray(tifffile.imread(path))
+    except ValueError as exc:
+        if "requires the 'imagecodecs' package" not in str(exc):
+            raise
+
+    if importlib.util.find_spec("PIL") is None:
+        raise RuntimeError("LZW TIFF read failed and Pillow fallback unavailable")
+
+    from PIL import Image, ImageSequence
+
+    with Image.open(path) as img:
+        frames = [np.array(frame, dtype=np.float32) for frame in ImageSequence.Iterator(img)]
+    if not frames:
+        raise RuntimeError(f"No frames decoded from TIFF: {path}")
+    return np.stack(frames, axis=0)
+
+
+@dataclass
+class NX46Config:
+    data_root: str = "/kaggle/input/vesuvius-challenge-ink-detection"
+    work_root: str = "/kaggle/working/nx46_vesuvius"
+    seed: int = 46
+    bit_capture_bytes: int = 256
+    threshold_quantile: float = 0.985
+    slab_min_neurons: int = 128
+    auto_discover_data_root: bool = True
+    strict_competition_mode: bool = True
+
+
+class ProgressRoadmap:
+    def __init__(self) -> None:
+        self.steps: Dict[str, float] = {
+            "audit_discovery": 0.0,
+            "train_thresholds": 0.0,
+            "infer_predictions": 0.0,
+            "package_submission": 0.0,
+            "finalize_forensics": 0.0,
+        }
+
+    def update(self, step: str, pct: float) -> None:
+        self.steps[step] = max(0.0, min(100.0, float(pct)))
+        print(f"[ROADMAP] {step}: {self.steps[step]:.1f}%")
+
+    def as_dict(self) -> Dict[str, float]:
+        return dict(self.steps)
+
+
+class HFBL360Logger:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+
+        self.forensic_log = root / "forensic_ultra.log"
+        self.core_log = root / "nx-46-vesuvius-core.log"
+        self.kaggle_log = root / "nx46-vesuvius-core-kaggle-ready.log"
+        self.metrics_csv = root / "metrics.csv"
+        self.state_json = root / "state.json"
+        self.bit_log = root / "bit_capture.log"
+        self.merkle_log = root / "merkle_chain.log"
+        self.discovery_json = root / "dataset_discovery_inventory.json"
+
+        with self.metrics_csv.open("w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(
+                [
+                    "timestamp_ns",
+                    "phase",
+                    "fragment",
+                    "neurons_active",
+                    "cpu_ns",
+                    "ink_pixels",
+                    "total_pixels",
+                    "ink_ratio",
+                    "merkle_prefix",
+                ]
+            )
+
+    def _append(self, line: str) -> None:
+        for p in (self.forensic_log, self.core_log, self.kaggle_log):
+            with p.open("a", encoding="utf-8") as f:
+                f.write(line + "\n")
+
+    def log_event(self, event: str, **data: object) -> None:
+        payload = json.dumps(data, ensure_ascii=False) if data else ""
+        self._append(f"{time.time_ns()} | {event}{(' | ' + payload) if payload else ''}")
+
+    def log_bits(self, fragment: str, payload: bytes) -> None:
+        bits = "".join(f"{b:08b}" for b in payload)
+        with self.bit_log.open("a", encoding="utf-8") as f:
+            f.write(f"{time.time_ns()} | {fragment} | {bits}\n")
+
+    def log_merkle(self, fragment: str, digest: str) -> None:
+        with self.merkle_log.open("a", encoding="utf-8") as f:
+            f.write(f"{time.time_ns()} | {fragment} | {digest}\n")
+
+    def log_metrics(
+        self,
+        *,
+        phase: str,
+        fragment: str,
+        neurons_active: int,
+        cpu_ns: int,
+        ink_pixels: int,
+        total_pixels: int,
+        merkle_prefix: str,
+    ) -> None:
+        ratio = (ink_pixels / total_pixels) if total_pixels else 0.0
+        with self.metrics_csv.open("a", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(
+                [
+                    time.time_ns(),
+                    phase,
+                    fragment,
+                    neurons_active,
+                    cpu_ns,
+                    ink_pixels,
+                    total_pixels,
+                    f"{ratio:.8f}",
+                    merkle_prefix,
+                ]
+            )
+
+    def write_state(self, state: Dict[str, object]) -> None:
+        state = dict(state)
+        state["timestamp_ns"] = time.time_ns()
+        self.state_json.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    def write_discovery_inventory(self, payload: Dict[str, object]) -> None:
+        self.discovery_json.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+class NX46AGNNVesuvius:
+    def __init__(self, cfg: NX46Config, logs_root: Path) -> None:
+        self.cfg = cfg
+        self.rng = np.random.default_rng(cfg.seed)
+        self.logger = HFBL360Logger(logs_root)
+        self.neurons_active = 0
+        self.total_allocations = 0
+        self.total_pixels_processed = 0
+        self.total_ink_pixels = 0
+        self.merkle_chain: List[str] = []
+        self.global_cpu_start_ns = time.process_time_ns()
+        self.logger.log_event("SYSTEM_STARTUP_L0_SUCCESS", config=cfg.__dict__)
+
+    def slab_allocate(self, tensor: np.ndarray, phase: str) -> int:
+        variance = float(np.var(tensor, dtype=np.float64))
+        entropy_proxy = float(np.mean(np.abs(np.gradient(tensor.astype(np.float32), axis=-1))))
+        required = int(self.cfg.slab_min_neurons + (tensor.size // 512) + variance * 1500.0 + entropy_proxy * 900.0)
+        self.neurons_active = max(self.cfg.slab_min_neurons, required)
+        self.total_allocations += 1
+        self.logger.log_event(
+            "SLAB_ALLOCATION",
+            phase=phase,
+            neurons=self.neurons_active,
+            variance=round(variance, 8),
+            entropy_proxy=round(entropy_proxy, 8),
+        )
+        return self.neurons_active
+
+    def _track_bits(self, fragment: str, arr: np.ndarray) -> None:
+        self.logger.log_bits(fragment, arr.tobytes()[: self.cfg.bit_capture_bytes])
+
+    def _merkle_sign(self, fragment: str, arr: np.ndarray) -> str:
+        prev = self.merkle_chain[-1] if self.merkle_chain else "GENESIS"
+        digest = sha512(prev.encode("utf-8") + arr.tobytes()).hexdigest()
+        self.merkle_chain.append(digest)
+        self.logger.log_merkle(fragment, digest)
+        return digest
+
+    @staticmethod
+    def _normalize_stack(stack: np.ndarray) -> np.ndarray:
+        x = stack.astype(np.float32)
+        mn, mx = float(x.min()), float(x.max())
+        if mx <= mn:
+            return np.zeros_like(x, dtype=np.float32)
+        return (x - mn) / (mx - mn)
+
+    @staticmethod
+    def _ink_energy_projection(stack: np.ndarray) -> np.ndarray:
+        grad_z = np.abs(np.diff(stack, axis=0, prepend=stack[:1]))
+        grad_y = np.abs(np.diff(stack, axis=1, prepend=stack[:, :1, :]))
+        grad_x = np.abs(np.diff(stack, axis=2, prepend=stack[:, :, :1]))
+        return np.mean(0.45 * grad_z + 0.30 * grad_y + 0.25 * grad_x, axis=0)
+
+    def train_threshold(self, stack: np.ndarray, labels: np.ndarray, fragment: str) -> float:
+        start = time.process_time_ns()
+        self.slab_allocate(stack, phase="train")
+        self._track_bits(fragment, stack)
+
+        score = self._ink_energy_projection(self._normalize_stack(stack))
+        pos = score[labels > 0]
+        neg = score[labels <= 0]
+        if pos.size and neg.size:
+            threshold = float(0.5 * (float(np.median(pos)) + float(np.median(neg))))
+        elif pos.size:
+            threshold = float(np.quantile(pos, 0.50))
+        else:
+            threshold = float(np.quantile(score, self.cfg.threshold_quantile))
+
+        pred = (score >= threshold).astype(np.uint8)
+        digest = self._merkle_sign(fragment, score)
+        cpu_ns = time.process_time_ns() - start
+
+        ink_pixels = int(pred.sum())
+        total_pixels = int(pred.size)
+        self.total_ink_pixels += ink_pixels
+        self.total_pixels_processed += total_pixels
+
+        self.logger.log_metrics(
+            phase="train",
+            fragment=fragment,
+            neurons_active=self.neurons_active,
+            cpu_ns=cpu_ns,
+            ink_pixels=ink_pixels,
+            total_pixels=total_pixels,
+            merkle_prefix=digest[:16],
+        )
+        self.logger.log_event("TRAIN_DONE", fragment=fragment, threshold=threshold)
+        return threshold
+
+    def infer_mask(self, stack: np.ndarray, threshold: float, fragment: str) -> np.ndarray:
+        start = time.process_time_ns()
+        self.slab_allocate(stack, phase="infer")
+        self._track_bits(fragment, stack)
+
+        score = self._ink_energy_projection(self._normalize_stack(stack))
+        pred = (score >= threshold).astype(np.uint8)
+        digest = self._merkle_sign(fragment, pred)
+        cpu_ns = time.process_time_ns() - start
+
+        ink_pixels = int(pred.sum())
+        total_pixels = int(pred.size)
+        self.total_ink_pixels += ink_pixels
+        self.total_pixels_processed += total_pixels
+
+        self.logger.log_metrics(
+            phase="infer",
+            fragment=fragment,
+            neurons_active=self.neurons_active,
+            cpu_ns=cpu_ns,
+            ink_pixels=ink_pixels,
+            total_pixels=total_pixels,
+            merkle_prefix=digest[:16],
+        )
+        self.logger.log_event("INFER_DONE", fragment=fragment)
+        return pred
+
+    def finalize(self, extra: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+        cpu_total_ns = time.process_time_ns() - self.global_cpu_start_ns
+        state = {
+            "runtime_status": "offline_activated",
+            "pipeline_status": "success",
+            "active_neurons": self.neurons_active,
+            "total_allocations": self.total_allocations,
+            "total_pixels_processed": self.total_pixels_processed,
+            "total_ink_pixels": self.total_ink_pixels,
+            "ink_ratio": self.total_ink_pixels / self.total_pixels_processed if self.total_pixels_processed else 0.0,
+            "qi_index_real": self.total_pixels_processed / max(cpu_total_ns, 1),
+            "cpu_total_ns": cpu_total_ns,
+            "merkle_root": self.merkle_chain[-1] if self.merkle_chain else None,
+        }
+        if extra:
+            state.update(extra)
+        self.logger.write_state(state)
+        self.logger.log_event("SYSTEM_LOADED_100_PERCENT")
+        return state
+
+
+def _to_stack(arr: np.ndarray) -> np.ndarray:
+    x = np.asarray(arr)
+    if x.ndim == 2:
+        return x[np.newaxis, ...]
+    if x.ndim == 3:
+        return x
+    raise RuntimeError(f"Unsupported TIFF shape: {x.shape}")
+
+
+def _read_fragment_stack(fragment_dir: Path) -> np.ndarray:
+    volume_dir = fragment_dir / "surface_volume"
+    files = sorted(volume_dir.glob("*.tif"))
+    if not files:
+        raise FileNotFoundError(f"No TIFF slices found in {volume_dir}")
+    return np.stack([_to_stack(read_tiff_lzw_safe(p))[0] for p in files], axis=0)
+
+
+def _load_label(fragment_dir: Path) -> Optional[np.ndarray]:
+    png = fragment_dir / "inklabels.png"
+    if not png.exists() or iio is None:
+        return None
+    arr = np.asarray(iio.imread(str(png)))
+    if arr.ndim == 3:
+        arr = arr[..., 0]
+    return (arr > 0).astype(np.uint8)
+
+
+def _read_sample_submission_ids(path: Path) -> List[str]:
+    ids: List[str] = []
+    with path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        cols = set(reader.fieldnames or [])
+        id_col = "Id" if "Id" in cols else ("id" if "id" in cols else None)
+        if id_col is None:
+            return ids
+        for row in reader:
+            v = str(row[id_col]).strip()
+            if v:
+                ids.append(v)
+    return ids
+
+
+def _dataset_inventory(root: Path) -> Dict[str, object]:
+    if not root.exists():
+        return {"root": str(root), "exists": False}
+
+    all_files = [p for p in root.rglob("*") if p.is_file()]
+    suffix_stats: Dict[str, int] = {}
+    folders = set()
+    for p in all_files:
+        suffix = p.suffix.lower() or "<noext>"
+        suffix_stats[suffix] = suffix_stats.get(suffix, 0) + 1
+        folders.add(str(p.parent.relative_to(root)))
+
+    return {
+        "root": str(root),
+        "exists": True,
+        "total_assets": len(all_files),
+        "folders": sorted(folders),
+        "suffix_stats": suffix_stats,
+    }
+
+
+def _discover_layout(root: Path) -> Tuple[str, List[Path], List[Path]]:
+    # Mode A: competition layout (reference notebooks)
+    test_images = root / "test_images"
+    if test_images.exists():
+        train_images = root / "train_images"
+        train = sorted(train_images.rglob("*.tif")) if train_images.exists() else []
+        test = sorted(test_images.rglob("*.tif"))
+        if test:
+            return "competition_test_images", train, test
+
+    # Mode B: fragment directories
+    train_dir = root / "train"
+    test_dir = root / "test"
+    if train_dir.exists() or test_dir.exists():
+        train = sorted([p for p in train_dir.iterdir() if p.is_dir() and (p / "surface_volume").exists()]) if train_dir.exists() else []
+        test = sorted([p for p in test_dir.iterdir() if p.is_dir() and (p / "surface_volume").exists()]) if test_dir.exists() else []
+        if test:
+            return "fragment_dirs", train, test
+
+    # Mode C: legacy flat tif dirs
+    train_legacy = sorted((root / "train_images").glob("*.tif")) if (root / "train_images").exists() else []
+    test_legacy = sorted((root / "test_images").glob("*.tif")) if (root / "test_images").exists() else []
+    if test_legacy:
+        return "legacy_tif_files", train_legacy, test_legacy
+
+    return "empty", [], []
+
+
+def _candidate_roots(primary_root: Path) -> List[Path]:
+    candidates: List[Path] = []
+
+    def add(p: Path) -> None:
+        if p.exists() and p not in candidates:
+            candidates.append(p)
+
+    add(primary_root)
+    add(Path("/kaggle/input/vesuvius-challenge-ink-detection"))
+    add(Path("/kaggle/input/vesuvius-challenge-surface-detection"))
+    add(Path("/kaggle/input/competitions/vesuvius-challenge-surface-detection"))
+
+    kaggle_input = Path("/kaggle/input")
+    if kaggle_input.exists():
+        for p in sorted(kaggle_input.iterdir()):
+            if p.is_dir() and "vesuvius" in p.name.lower():
+                add(p)
+
+    competitions = Path("/kaggle/input/competitions")
+    if competitions.exists():
+        for p in sorted(competitions.iterdir()):
+            if p.is_dir() and "vesuvius" in p.name.lower():
+                add(p)
+
+    return candidates
+
+
+def _resolve_root(primary_root: Path, auto_discover: bool) -> Tuple[Path, str, List[Dict[str, object]]]:
+    roots = _candidate_roots(primary_root) if auto_discover else [primary_root]
+    attempts: List[Dict[str, object]] = []
+
+    for root in roots:
+        mode, train, test = _discover_layout(root)
+        attempts.append({"root": str(root), "mode": mode, "train": len(train), "test": len(test)})
+        if test:
+            return root, mode, attempts
+
+    return primary_root, "empty", attempts
+
+
+def _load_train_item(item: Path, mode: str) -> Tuple[np.ndarray, Optional[np.ndarray], str]:
+    if mode == "fragment_dirs":
+        stack = _read_fragment_stack(item)
+        labels = _load_label(item)
+        return stack, labels, item.name
+
+    stack = _to_stack(read_tiff_lzw_safe(item))
+
+    # Optional labels in train_labels (legacy/competition variants)
+    labels = None
+    labels_tif = item.parent.parent / "train_labels" / item.name
+    labels_png = item.parent.parent / "train_labels" / item.with_suffix(".png").name
+    if labels_tif.exists():
+        l = read_tiff_lzw_safe(labels_tif)
+        labels = (l[0] > 0).astype(np.uint8) if l.ndim == 3 else (l > 0).astype(np.uint8)
+    elif labels_png.exists() and iio is not None:
+        l = np.asarray(iio.imread(str(labels_png)))
+        labels = (l[..., 0] > 0).astype(np.uint8) if l.ndim == 3 else (l > 0).astype(np.uint8)
+
+    return stack, labels, item.stem
+
+
+def _load_test_item(item: Path, mode: str) -> Tuple[np.ndarray, str]:
+    if mode == "fragment_dirs":
+        return _read_fragment_stack(item), f"{item.name}.tif"
+    return _to_stack(read_tiff_lzw_safe(item)), item.name
+
+
+def _write_submission_csv(out_csv: Path, sample_csv: Path, predictions: Dict[str, np.ndarray]) -> Optional[str]:
+    ids = _read_sample_submission_ids(sample_csv)
+    if not ids:
+        return None
+
+    flat = np.concatenate([predictions[k].reshape(-1).astype(np.uint8) for k in sorted(predictions)])
+    n = min(len(ids), len(flat))
+
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["Id", "Predicted"])
+        for i in range(n):
+            w.writerow([ids[i], int(flat[i])])
+    return str(out_csv)
+
+
+def _write_submission_zip(out_zip: Path, predictions: Dict[str, np.ndarray]) -> str:
+    out_zip.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = out_zip.parent / "submission_masks"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    names: List[str] = []
+    for tif_name, mask in predictions.items():
+        mask2d = (mask > 0).astype(np.uint8)
+        p = tmp_dir / tif_name
+        tifffile.imwrite(str(p), mask2d[np.newaxis, ...], compression="LZW")
+        names.append(tif_name)
+
+    with zipfile.ZipFile(out_zip, "w", compression=zipfile.ZIP_STORED) as zf:
+        for name in sorted(names):
+            zf.write(tmp_dir / name, arcname=name)
+
+    return str(out_zip)
+
+
+def _validate_zip(out_zip: Path, expected_tif_names: Sequence[str]) -> Dict[str, object]:
+    with zipfile.ZipFile(out_zip, "r") as zf:
+        got = sorted([Path(n).name for n in zf.namelist() if n.lower().endswith(".tif")])
+    exp = sorted(expected_tif_names)
+    return {
+        "status": "ok" if got == exp else "mismatch",
+        "expected_test_files": len(exp),
+        "submission_tif_files": len(got),
+        "missing": sorted(set(exp) - set(got)),
+        "unexpected": sorted(set(got) - set(exp)),
+    }
+
+
+def run_pipeline(cfg: NX46Config) -> Dict[str, object]:
+    configured_root = Path(cfg.data_root)
+    work = Path(cfg.work_root)
+    logs_root = work / "logs"
+    logs_root.mkdir(parents=True, exist_ok=True)
+
+    roadmap = ProgressRoadmap()
+    nx46 = NX46AGNNVesuvius(cfg, logs_root)
+
+    effective_root, mode, attempts = _resolve_root(configured_root, cfg.auto_discover_data_root)
+    mode, train_items, test_items = _discover_layout(effective_root)
+
+    inventory = _dataset_inventory(effective_root)
+    nx46.logger.write_discovery_inventory({"attempts": attempts, "inventory": inventory})
+    nx46.logger.log_event("DATASET_DISCOVERY", mode=mode, configured_root=str(configured_root), effective_root=str(effective_root), attempts=attempts)
+    roadmap.update("audit_discovery", 100.0)
+
+    if not test_items:
+        nx46.logger.log_event("NO_TEST_INPUTS_FOUND", attempts=attempts)
+        raise RuntimeError(
+            "No test inputs found. Checked roots: "
+            + ", ".join([a["root"] for a in attempts])
+            + ". Configure NX46_DATA_ROOT to the dataset root containing test_images or test/<fragment>."
+        )
+
+    thresholds: List[float] = []
+    total_train = max(1, len(train_items))
+    for idx, item in enumerate(train_items, start=1):
+        roadmap.update("train_thresholds", idx * 100.0 / total_train)
+        nx46.logger.log_event("PROGRESS_TRAIN", index=idx, total=len(train_items))
+        stack, labels, name = _load_train_item(item, mode)
+        if labels is None:
+            continue
+        if labels.shape != stack.shape[1:]:
+            h = min(labels.shape[0], stack.shape[1])
+            w = min(labels.shape[1], stack.shape[2])
+            labels = labels[:h, :w]
+            stack = stack[:, :h, :w]
+        thresholds.append(nx46.train_threshold(stack, labels, name))
+
+    threshold = float(np.median(np.asarray(thresholds, dtype=np.float32))) if thresholds else 0.5
+    nx46.logger.log_event("THRESHOLD_SELECTED", threshold=threshold, trained_samples=len(thresholds))
+
+    predictions: Dict[str, np.ndarray] = {}
+    expected_names: List[str] = []
+
+    total_test = max(1, len(test_items))
+    for idx, item in enumerate(test_items, start=1):
+        roadmap.update("infer_predictions", idx * 100.0 / total_test)
+        nx46.logger.log_event("PROGRESS_TEST", index=idx, total=len(test_items))
+        stack, tif_name = _load_test_item(item, mode)
+        pred = nx46.infer_mask(stack, threshold, Path(tif_name).stem)
+        predictions[tif_name] = pred
+        expected_names.append(tif_name)
+
+    roadmap.update("package_submission", 20.0)
+
+    sample_csv_candidates = [
+        effective_root / "sample_submission.csv",
+        Path("/kaggle/input/vesuvius-challenge-ink-detection/sample_submission.csv"),
+        Path("/kaggle/input/vesuvius-challenge-surface-detection/sample_submission.csv"),
+        Path("/kaggle/input/competitions/vesuvius-challenge-surface-detection/sample_submission.csv"),
+    ]
+    sample_csv = next((p for p in sample_csv_candidates if p.exists()), None)
+
+    submission_csv: Optional[str] = None
+    if sample_csv is not None:
+        submission_csv = _write_submission_csv(work / "submission.csv", sample_csv, predictions)
+
+    submission_zip = _write_submission_zip(work / "submission.zip", predictions)
+    validation = _validate_zip(Path(submission_zip), expected_names)
+    nx46.logger.log_event("COMPETITION_RULES_VALIDATION", **validation)
+    roadmap.update("package_submission", 100.0)
+
+    if cfg.strict_competition_mode and validation["status"] != "ok":
+        raise RuntimeError(f"Submission zip validation failed: {validation}")
+
+    roadmap.update("finalize_forensics", 60.0)
+    result = nx46.finalize(
+        {
+            "status": "100%_OFFLINE_ACTIVATED",
+            "layout_detected": mode,
+            "configured_data_root": str(configured_root),
+            "effective_data_root": str(effective_root),
+            "discovery_attempts": attempts,
+            "train_items": [p.name for p in train_items],
+            "test_items": [p.name for p in test_items],
+            "train_threshold": threshold,
+            "submission_csv": submission_csv,
+            "submission_zip": submission_zip,
+            "zip_members_validated": validation["status"] == "ok",
+            "zip_missing": validation["missing"],
+            "zip_extra": validation["unexpected"],
+            "competition_rules_validation": validation,
+            "roadmap_percent": roadmap.as_dict(),
+        }
+    )
+
+    roadmap.update("finalize_forensics", 100.0)
+    # Compatibility files present in previous forensic bundles.
+    (logs_root / "RkF4XakI.txt").write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    (logs_root / "UJxLRsEE.txt").write_text(json.dumps(validation, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    nx46.logger.log_event("EXEC_COMPLETE", submission=submission_zip)
+    return result
+
+
+if __name__ == "__main__":
+    config = NX46Config(
+        data_root=os.environ.get("NX46_DATA_ROOT", NX46Config.data_root),
+        work_root=os.environ.get("NX46_WORK_ROOT", NX46Config.work_root),
+    )
+    out = run_pipeline(config)
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    print(f"READY: {out['submission_zip']}")


### PR DESCRIPTION
### Motivation
- Corriger la non-détection des entrées et le comportement « tout à zéro » en réutilisant les méthodes de découverte et de lecture de TIFF déjà validées dans le notebook de référence. 
- Prendre en charge l’installation hors-ligne des dépendances présentes dans `/kaggle/input/datasets/ndarray2000/nx47-dependencies` (avec fallback) pour assurer l’exécution cohérente en environnement Kaggle offline. 
- Produire une version forensic, stricte et compatible compétition qui échoue clairement en cas d’absence d’entrées test au lieu de terminer silencieusement.

### Description
- Ajout du script principal `RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v3.py` qui réintègre la stratégie notebook éprouvée: `install_offline`, `bootstrap_dependencies_fail_fast`, `ensure_imagecodecs` et `read_tiff_lzw_safe` pour une lecture TIFF LZW robuste et recovery codec + Pillow fallback. 
- Implémentation d’une découverte de dataset alignée sur les versions de référence avec priorités et modes: `competition_test_images` (`test_images/*.tif`), `fragment_dirs` (`train/<id>/surface_volume` et `test/<id>/surface_volume`) puis `legacy_tif_files`, plus auto-discovery multi-racines Kaggle (incluant `competitions/...`). 
- Ajout d’un inventaire forensic exporté dans `dataset_discovery_inventory.json`, logs détaillés (`forensic_ultra.log`, `nx-46-vesuvius-core.log`, `metrics.csv`, `state.json`, etc.), génération stricte de `submission.zip` (TIFF LZW) et option `submission.csv`, et validation fail-fast des membres du zip en mode strict. 
- Ajout du script v2 et d’un rapport de réintégration `RAPPORT-VESUVIUS/RAPPORT_REINTEGRATION_NX46_V3_FROM_NOTEBOOK_1771124473890.md` documentant précisément les éléments repris depuis le notebook de référence.

### Testing
- Vérification programmatique dans le notebook fourni pour s’assurer que les snippets clés existent (recherche des fonctions `install_offline`, `bootstrap_dependencies_fail_fast`, `ensure_imagecodecs`, `read_tiff_lzw_safe`, `discover_inputs` et du chemin `/kaggle/input/datasets/ndarray2000/nx47-dependencies`); la recherche a trouvé les éléments attendus (succès). 
- Compilation statique des scripts Python avec `python -m py_compile RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v3.py RAPPORT-VESUVIUS/src_vesuvius/nx46-vesuvius-core-kaggle-ready-v2.py` qui a réussi (aucune erreur de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933e9356d0832bb6a06fe3917dcb2c)