### PR TITLE
Update V7.5 roadmap and add score-driven density forensic analysis for V144.1/V7.5

### DIFF
--- a/RAPPORT-VESUVIUS/BILAN_AUDIT_COMPLET_V1441_V612_V72_CONCURRENT_20260219.md
+++ b/RAPPORT-VESUVIUS/BILAN_AUDIT_COMPLET_V1441_V612_V72_CONCURRENT_20260219.md
@@ -1,0 +1,353 @@
+# BILAN D’AUDIT COMPLET (NOUVEAU) — V144.1 vs V61.2 vs V7.2 vs Concurrent
+
+Date: 2026-02-19  
+Auteur: Agent Codex (audit forensique + lecture code complète)  
+Périmètre réel audité:  
+- `RAPPORT-VESUVIUS/notebook-version-NX47-V144.1/*`  
+- `RAPPORT-VESUVIUS/notebook-version-NX47-V61.2/*`  
+- `RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/output_logs_vesuvius/v7.2-outlput-logs--nx46-vesuvius-core-kaggle-ready/*`  
+- `RAPPORT-VESUVIUS/exemple-soumision-notebook-concurrent/*`  
+- fichiers de contexte demandés: `nx46_vesuvius_plan.md`, `RAPPORT_IAMO3/NX/PRESENTATION_COMPLETE_DECOUVERTES_NX1_NX42.md`.
+
+---
+
+## 0) Problèmes rencontrés (notification obligatoire)
+
+1. Deux documents demandés n’ont pas été trouvés dans le dépôt sous le nom exact:  
+   - `DOCUMENTATION_AUDIT_EXPERT_NX46.md`  
+   - `NX47_VESU_PLAN.md`
+2. Les artefacts V144.1 portent encore des noms internes `v139_*` (anomalie de versionning interne).
+3. Les scores Kaggle leaderboard explicites pour V144.1 et V7.2 ne sont pas présents dans les artefacts audités ici.
+4. Pour l’inspection TIFF détaillée, installation locale de dépendances d’audit (`tifffile`, `imagecodecs`) nécessaire.
+
+---
+
+## 1) “Visionning” / actualisation entre versions (point de discipline)
+
+Tu as raison sur le fond: l’audit doit être **ré-actualisé à chaque version**.  
+Dans ce bilan, j’ai donc forcé une méthode systématique:
+
+- lecture des logs d’exécution complets,
+- inspection de chaque `results.zip` et des `submission.zip` imbriqués,
+- extraction des paramètres globaux et de progression,
+- comparaison technique version par version,
+- contrôle code V144.1 sans TODO/stub/smoking.
+
+Standard proposé pour la suite (automatique):  
+**à chaque nouvelle version** → check-list fixe: `code + logs + zip + tiff + params + roadmap + questions ouvertes`.
+
+---
+
+## 2) Lecture complète du code V144.1 (de la première à la dernière ligne)
+
+## 2.1 Résumé structurel du notebook V144.1
+
+- Fichier: `nx47-vesu-kernel-new-v144-1.ipynb`
+- Cellules code: **1** (grosse cellule monolithique)
+- Lignes code extraites: **2017**
+- Fonctions définies: **29**
+- Classes définies: **1** (`_TinyUNet2p5D`)
+
+### Fonctions clés réellement présentes
+- Dépendances offline: `_is_pkg_available`, `install_offline`, `bootstrap_dependencies_fail_fast`, `ensure_imagecodecs`
+- I/O TIFF: `read_tiff_lzw_safe`, `write_tiff_lzw_safe`
+- Apprentissage / calibration: `train_unet_25d_supervised`, `train_nx47_supervised`, `train_nx47_autonomous`, `calibrate_thresholds`, `calibrate_target_ratio`
+- Fusion / post-traitement: `slice_adaptive_fusion`, `hysteresis_topology_3d`
+- Feature engineering: `extract_multi_features`, `auto_select_features`, `pseudo_labels`
+
+## 2.2 Contrôle anti-faux-semblant demandé
+
+- `TODO`: **0**
+- `FIXME`: **0**
+- `stub`: **0**
+- `smoking`: **0**
+- `pass` nus: **4** (à surveiller fonctionnellement)
+
+Conclusion: je n’ai pas trouvé de placeholder explicite ni de stub textuel dans le code V144.1.
+
+## 2.3 Intégration technologies “réelles” observables
+
+- Mentions forensics/merkle/memory tracker: **présentes** (forensic 26+, merkle 8+, memory_tracker présent)
+- Supervised training: **présent** (mentions nombreuses)
+- U-Net 2.5D: **présent** (`_TinyUNet2p5D` + routine train)
+- Lean/Aristotle: **absent** dans ce notebook V144.1 (0 mention)
+
+=> Donc V144.1 est une intégration ML/forensic Kaggle, pas une chaîne Lean4 active.
+
+---
+
+## 3) Audit profond des résultats — fichier par fichier, paramètre par paramètre
+
+## 3.1 V144.1 (corrigée)
+
+### A) Logs
+- `s0zulCMY.txt`: 4080 lignes, erreurs fatales: 0, warnings: 6
+- `nx47-vesu-kernel-new-v144-1.log`: 4080 lignes, erreurs fatales: 0, warnings: 6
+- événements clés présents: `SUPERVISED_TRAIN`, `GLOBAL_STATS`, `EXEC_COMPLETE`, `READY:`
+
+### B) ZIP et artefacts
+- `results.zip` contient:
+  - `submission.zip`
+  - `v139_execution_logs.json`
+  - `v139_execution_metadata.json`
+  - `v139_forensic_analysis_report.json`
+  - `v139_memory_tracker.json`
+  - `v139_roadmap_realtime.json`
+  - `v139_ultra_authentic_360_merkle.jsonl`
+
+### C) Soumission TIFF
+- `submission.zip/1407735.tif`
+  - shape: `(320,320,320)`
+  - dtype: `uint8`
+  - min/max: `0/255`
+  - mean: `15.3`
+
+### D) Paramètres d’apprentissage extraits
+- `train_samples`: **960000**
+- `val_samples`: **320000**
+- `epochs_effective`: **6**
+- `adaptive_lr`: **0.08**
+- `mutation_applied`: **False**
+- `pruning_applied`: **True**
+
+### E) Qualité de validation rapportée (interne)
+- `val_f1`: **0.0**
+- `val_iou`: **0.0**
+- `val_dice`: **0.0**
+- `val_fbeta`: **0.0**
+- `best_threshold`: **0.35**
+- `objective`: **0.10530677559263577**
+
+### F) Comportement “neurones” (dynamique)
+- `active_neurons_start_total`: **0**
+- `active_neurons_mid_total`: **6**
+- `active_neurons_end_total`: **6**
+=> Interprétation: activation tardive minimale, puis plateau (pas d’expansion neuronale au-delà de 6 actifs).
+
+### G) Progression process
+- `PROGRESS_UPDATE`: **3863 événements**
+- `roadmap overall progress`: **86.67%**
+- `train_pair_coverage_pct`: **4.071246819338422%** (faible couverture)
+
+### H) Global stats
+- `files_processed`: 1
+- `slices_processed`: 320
+- `pixels_processed`: 32,768,000
+- `patterns_detected`: 933
+- `anomalies_detected`: 52
+- `unknown_discoveries`: 0
+
+=> Sur cette exécution, le pipeline **tourne** et trace, mais les métriques val F1/IoU nulles indiquent un apprentissage peu discriminant côté validation interne.
+
+---
+
+## 3.2 V61.2 (version scorée de référence)
+
+### A) Logs
+- `BRzSoZeY.txt` + `.log`: 87 lignes, erreurs fatales: 0, warnings: 4
+- événements visibles: `FUSION_SCORE_GLOBAL`, `EXEC_COMPLETE`, `READY:`
+
+### B) ZIP
+- `results.zip` contient:
+  - `final_logs/forensic_audit_1771420660.log`
+  - `nx47_vesuvius/submission.zip`
+  - `submission.zip`
+  - `v28_forensic_logs/forensic_v28_....log`
+  - `v28_forensic_logs/wal_....bin`
+
+### C) Soumission TIFF
+- 3D `(320,320,320)`
+- `uint8` binaire `0/1`
+- mean: `0.12256454467773438`
+
+=> V61.2 a la sortie la plus “propre” en binaire strict 0/1 parmi les versions NX47 comparées ici.
+
+---
+
+## 3.3 V7.2 (branche NX46, artefact output_logs)
+
+### A) Logs
+- `ZA5jJ6j8.txt`: 1423 lignes, warnings: 4, `READY:` présent
+
+### B) ZIP
+- `results.zip` contient logs riches (`metrics.csv`, `state.json`, `merkle_chain.log`, `bit_capture.log`, etc.)
+- état global (`state.json`):
+  - `runtime_status`: `offline_activated`
+  - `pipeline_status`: `success`
+  - `active_neurons`: **1,257,219**
+  - `total_allocations`: 513
+  - `total_pixels_processed`: 51,499,008
+  - `total_ink_pixels`: 25,700,716
+  - `ink_ratio`: 0.49905264194603516
+  - `cpu_total_ns`: 1,621,008,468,584
+
+### C) Soumission
+- `submission.zip/1407735.tif` en **2D** `(320,320)` `uint8` `0/255`
+- masque `submission_masks/1407735.tif` idem
+
+=> Contrairement à V61.2/V144.1 (3D), cet artefact v7.2 exporte une sortie 2D, ce qui est structurellement différent.
+
+---
+
+## 3.4 Version concurrente (exemple 0.552)
+
+### A) Logs
+- `qmSqO2X8.txt`: 1287 lignes
+
+### B) Soumission
+- `results.zip/submission.zip/1407735.tif`
+  - shape `(320,320,320)`
+  - `uint8`
+  - `0/1`
+  - mean `0.09412158203125`
+
+=> Le concurrent suit, sur cet artefact, la logique volumique 3D binaire 0/1.
+
+---
+
+## 4) Comparaison benchmark complète (phase par phase)
+
+## 4.1 Phase A — Compatibilité format soumission
+
+- V61.2: ✅ 3D
+- V144.1: ✅ 3D
+- Concurrent: ✅ 3D
+- V7.2: ⚠️ 2D
+
+## 4.2 Phase B — Type de binaire masque
+
+- V61.2: `0/1`
+- Concurrent: `0/1`
+- V144.1: `0/255`
+- V7.2: `0/255`
+
+Risque: écarts de post-traitement/scoring si pipeline aval attend strictement `0/1`.
+
+## 4.3 Phase C — Processus d’apprentissage observable
+
+- V144.1:
+  - apprentissage supervisé déclaré,
+  - 960k train / 320k val,
+  - 6 epochs effectives,
+  - mutation off, pruning on,
+  - mais val F1/IoU/Dice/Fbeta à 0.0.
+- V61.2:
+  - pipeline plus compact (logs courts),
+  - sortie robuste 3D 0/1,
+  - version associée à score 0.387 (contexte projet).
+- V7.2:
+  - instrumentation runtime/mémoire/merkle très riche,
+  - population neurones massive reportée,
+  - sortie 2D (écart structurel avec cible 3D).
+
+## 4.4 Phase D — Forensic / traçabilité nanoseconde
+
+- V144.1: très forte traçabilité JSON + merkle + memory tracker.
+- V7.2: traçabilité opérationnelle très riche (`metrics.csv`, state, bit_capture, merkle logs).
+- V61.2: traçabilité plus légère que V144.1/v7.2.
+
+## 4.5 Phase E — Différences de “neurone total”
+
+D’après les artefacts:
+- V61.2 = pipeline NX47 compact, orienté sortie conforme et run rapide.
+- V144.1 = pipeline NX47 plus lourd, supervisé + forensic intense, mais métriques val internes faibles.
+- V7.2 = pipeline NX46 orienté instrumentation “système”, pas aligné 3D sur cet artefact précis.
+
+Conclusion comparative: **ce n’est pas le même comportement global**, ni la même stratégie d’optimisation entre V61.2, V7.2 et V144.1.
+
+---
+
+## 5) Réponses directes à tes questions expertes (sans esquive)
+
+## 5.1 “Est-ce qu’il a appris quelque chose ?”
+
+- V144.1: il y a apprentissage exécuté (train/val/epochs/updates), mais indicateurs val F1/IoU/Dice/Fbeta = 0.0 dans ces artefacts.
+- Donc: **apprentissage processuel oui**, **apprentissage performant non démontré** par ces métriques.
+
+## 5.2 “Combien de neurones avant/pendant/après ?”
+
+- V144.1 (global stats): 0 → 6 → 6 actifs.
+- V7.2 (`state.json`): 1,257,219 actifs reportés (autre architecture).
+
+## 5.3 “Formule, axiome, lemme, Lean4 généré ? interactions Lean/IA ?”
+
+Sur le périmètre audité ici:
+- aucune formule/axiome/lemme Lean4 générée dans V144.1,
+- aucun fichier Lean4 trouvé dans ces artefacts V144.1/V61.2/V7.2/concurrent,
+- interactions Lean4 observées: **0**,
+- interactions IA internes quantifiées de manière fine: non exposées explicitement en “nombre de tours LLM” dans ces logs.
+
+## 5.4 “Comment il pense / apprend par tranche / temps par tranche ?”
+
+Ce qui est objectivement traçable:
+- V144.1: 3863 `PROGRESS_UPDATE`, 320 slices processées, exécution complète ~2600s.
+- V7.2: `cpu_total_ns` fourni et `metrics.csv` par fragment (513 allocations/étapes).
+
+Ce qui manque encore pour répondre à 100% de ta demande:
+- un export standardisé “per-slice learning table” unifié (temps, score local, succès/échec par tranche).
+
+---
+
+## 6) Alignement avec les docs demandés
+
+## 6.1 `nx46_vesuvius_plan.md`
+- Le plan insiste sur adaptation NX46 + logs HFBL-360 + tests unitaires/intégration.
+- Dans l’artefact v7.2, on voit effectivement des preuves de logs opérationnels (metrics/state/merkle/bit_capture), donc une partie de l’esprit du plan est appliquée.
+
+## 6.2 `PRESENTATION_COMPLETE_DECOUVERTES_NX1_NX42.md`
+- Ce document parle d’invariants/hystérésis/mémoire dissipative/traçabilité Merkle.
+- Ces thèmes sont partiellement matérialisés dans les journaux V144.1 et v7.2 (hysteresis, merkle, forensic), mais pas tous au même niveau d’explicitation formelle.
+
+## 6.3 Fichiers introuvables
+- `DOCUMENTATION_AUDIT_EXPERT_NX46.md`: non trouvé.
+- `NX47_VESU_PLAN.md`: non trouvé.
+
+Action requise: fournir les chemins exacts si les noms diffèrent.
+
+---
+
+## 7) Questions critiques restant sans réponse (bloquants)
+
+1. Score leaderboard final de V144.1 ? (absent ici)
+2. Score leaderboard final de v7.2 ? (absent ici)
+3. A/B mesuré `0/1` vs `0/255` sur même seed/modèle: quel impact réel LB ?
+4. Pourquoi V144.1 publie encore des artefacts `v139_*` ?
+5. Comment standardiser un tableau “apprentissage par tranche” pour audit pédagogique total ?
+
+---
+
+## 8) Plan d’amélioration immédiatement actionnable
+
+## P0 (immédiat)
+- Corriger version stamping interne (noms `v139_*` -> version réelle).
+- Ajouter export CSV/JSON standard **par tranche**: `slice_id, train_time_ms, infer_time_ms, local_confidence, success_flag`.
+- Uniformiser sortie soumission en 3D binaire strict configurable (`0/1` prioritaire, `0/255` option explicite).
+
+## P1 (benchmark)
+- Bench A/B/C strict:
+  1) V61.2 baseline,
+  2) V144.1 actuel,
+  3) V144.1 + sortie 0/1 + calibration revue.
+- Mesurer: LB score, runtime, mémoire, stabilité hash forensics.
+
+## P2 (gouvernance)
+- Déployer un template unique “version card” pour chaque dossier version:
+  - architecture,
+  - paramètres,
+  - logs clés,
+  - score,
+  - anomalies,
+  - décisions.
+
+---
+
+## 9) Verdict exécutif
+
+- V144.1 est **fonctionnelle runtime** et fortement instrumentée forensic.
+- Mais ses métriques validation internes sont faibles (F1/IoU/Dice/Fbeta = 0.0).
+- V61.2 reste la référence scorée/compacte la plus propre dans ce périmètre.
+- V7.2 apporte une instrumentation système massive mais avec sortie 2D sur cet artefact.
+- Le concurrent (artefact fourni) suit une sortie 3D binaire 0/1 cohérente.
+
+En clair: pour gagner en score de manière robuste, la priorité est de **combiner la conformité de V61.2 + la traçabilité de V144.1 + la granularité runtime de v7.2**, puis valider par A/B scoré réel.
+

--- a/RAPPORT-VESUVIUS/RAPPORT_ANALYSE_PROFONDE_V1401_V1441_GITHUB_PULL_20260218.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_ANALYSE_PROFONDE_V1401_V1441_GITHUB_PULL_20260218.md
@@ -1,0 +1,202 @@
+# RAPPORT D’ANALYSE PROFONDE (MODE COURS) — V140.1 vs V144.1 après synchronisation GitHub
+
+Date: 2026-02-18  
+Périmètre: `RAPPORT-VESUVIUS/notebook-version-NX47-V140.1`, `RAPPORT-VESUVIUS/notebook-version-NX47-V144.1`, comparaison avec `V61.2` (scorée), audit des plans/feuilles de route.
+
+---
+
+## 0) Expertises mobilisées (annoncées explicitement)
+
+1. **MLOps forensique Kaggle** (inspection ZIP imbriqués, conformité package de soumission, traçabilité d’exécution).
+2. **Computer Vision 3D / Vesuvius** (validation TIFF volumique `(320,320,320)`, typage `uint8`, densité du masque).
+3. **Data/Log Forensics** (analyse structurée des logs `.txt`/`.log`, signatures, patterns temporels, anomalies).
+4. **Software Quality Audit** (contrôle anti-placeholder/stub/hardcoding, cohérence de versionnage).
+5. **Gouvernance technique** (audit plans et feuilles de route sur l’arborescence RAPPORT-VESUVIUS).
+
+---
+
+## 1) Re-synchronisation dépôt distant GitHub (problème demandé + résolution)
+
+Vous aviez raison: il fallait repartir avec logique “distant GitHub”.
+
+- `origin` a été (re)configuré vers `https://github.com/lumc01/Lumvorax.git`.
+- `git fetch origin --prune` exécuté avec succès.
+- `git pull --ff-only origin main` exécuté, résultat: **Already up to date**.
+
+✅ Conclusion: l’état local courant est déjà aligné avec `origin/main` au moment de l’analyse.
+
+---
+
+## 2) Inspection profonde V140.1 et V144.1 (ZIP extraits + logs)
+
+## 2.1 Résultats techniques bruts
+
+### V140.1
+- `results.zip` contient:
+  - `submission.zip`
+  - `v139_execution_logs.json`
+  - `v139_execution_metadata.json`
+  - `v139_forensic_analysis_report.json`
+  - `v139_memory_tracker.json`
+  - `v139_roadmap_realtime.json`
+  - `v139_ultra_authentic_360_merkle.jsonl`
+- `submission.zip` contient `1407735.tif`:
+  - shape `(320, 320, 320)`
+  - dtype `uint8`
+  - min/max `0/255`
+  - mean `15.3`
+- logs `Yl-2S3gi.txt` / `nx47-vesu-kernel-new-v140-1.log`:
+  - 4080 lignes, pas de traceback fatal,
+  - événement `EXEC_COMPLETE` + `READY: /kaggle/working/submission.zip`,
+  - warnings de tooling (traitlets/nbconvert), non bloquants.
+
+### V144.1
+- `results.zip` contient exactement la même structure interne que V140.1 (mêmes noms d’artefacts).
+- `submission.zip` contient `1407735.tif`:
+  - shape `(320, 320, 320)`
+  - dtype `uint8`
+  - min/max `0/255`
+  - mean `15.3`
+- logs `s0zulCMY.txt` / `nx47-vesu-kernel-new-v144-1.log`:
+  - 4080 lignes, pas de traceback fatal,
+  - événement `EXEC_COMPLETE` + `READY: /kaggle/working/submission.zip`,
+  - warnings de tooling (traitlets/nbconvert), non bloquants.
+
+---
+
+## 2.2 Nouvelles découvertes (inconnues) et anomalies importantes
+
+### A1) **Anomalie de versionnage interne**
+Bien que les dossiers soient `V140.1` et `V144.1`, les artefacts embarqués sont nommés **`v139_*`** et les métadonnées déclarent `"version": "NX47 V139"`.
+
+➡️ Cela signale un **décalage d’identifiant de version** (version tag non propagée) pouvant brouiller l’audit, la reproductibilité et la gouvernance des runs.
+
+### A2) **Artefacts internes V140.1 et V144.1 strictement identiques**
+Les hashes SHA256 des fichiers internes de `results.zip` (dont `submission.zip`, metadata, logs JSON, merkle) sont identiques entre V140.1 et V144.1.
+
+➡️ Hypothèse forte: V144.1 et V140.1 pointent vers **le même résultat de run effectif** (ou un ré-emballage quasi identique), donc pas de divergence mesurable entre ces deux runs corrigés.
+
+### A3) **Différence de binaire sortie par rapport à V61.2**
+- V61.2: TIFF binaire `0/1` (mean ≈ 0.12256).
+- V140.1/V144.1: TIFF binaire `0/255` (mean 15.3).
+
+➡️ C’est souvent acceptable selon pipeline de scoring (normalisation possible), mais c’est une **source de variance potentielle** entre versions, à verrouiller explicitement.
+
+### A4) **Pattern de stabilité d’exécution**
+- Les deux runs corrigés atteignent `EXEC_COMPLETE` autour de ~2600s.
+- Les warnings observés sont principalement Python/nbconvert (pas ML/IO critique).
+
+➡️ Sur le plan runtime offline, la chaîne est stable et termine sans erreur bloquante.
+
+---
+
+## 3) Comparaison détaillée avec dernières versions scorées/finalisées
+
+## 3.1 V61.2 (score confirmé 0.387 dans l’historique projet)
+- V61.2 est la référence scorée disponible.
+- Packaging: `submission.zip` + structure de logs forensiques existante.
+- Sortie volumique OK `(320,320,320)`, `uint8`.
+
+## 3.2 Différences V140.1/V144.1 vs V61.2
+
+1. **Sortie binaire**: `0/255` (V140.1/V144.1) vs `0/1` (V61.2).
+2. **Empreinte forensique**: V140.1/V144.1 publient un lot `v139_*` plus “lourd” en traçabilité.
+3. **Runtime**: V140.1/V144.1 significativement plus longs (ordre de grandeur 2600s) que V61.2 (ordre de dizaines de secondes selon logs disponibles).
+
+## 3.3 Ce que cela implique
+- Les runs V140.1/V144.1 semblent robustes “sans erreur”, mais **l’absence de score LB associé dans les artefacts** empêche de conclure sur le gain compétitif réel.
+- Sans score Kaggle, une exécution “propre” reste un **succès technique**, pas une preuve de performance leaderboard.
+
+---
+
+## 4) Audit code anti-placeholder / anti-stub / hardcoding
+
+Contrôle sur:
+- `notebook-version-NX47-V140/nx47-vesu-kernel-new-v140.py`
+- `notebook-version-NX47-V144/nx47-vesu-kernel-new-v144.py`
+
+Constats:
+- `TODO`: 0
+- `FIXME`: 0
+- `placeholder`: 0
+- `stub`: 0
+- `pass` trouvés: 4 dans chaque fichier (à vérifier contextuellement; non conclusif sans contexte fonctionnel de chaque bloc).
+- chemins Kaggle hardcodés `/kaggle/input` présents (9 occurrences/fichier), ce qui est normal pour notebook Kaggle mais à encapsuler pour meilleure portabilité locale.
+
+Conclusion qualité:
+- Pas d’indicateur de faux-semblant explicite (`placeholder/stub`) détecté dans ce scan.
+- Point d’amélioration: abstraction des chemins d’entrée/sortie pour audit cross-environnement.
+
+---
+
+## 5) Vérification plans + feuilles de route (dossier et sous-dossiers RAPPORT-VESUVIUS)
+
+Inventaire régénéré dans `plan_roadmap_audit_inventory.json`.
+
+### 5.1 Statut global
+- Les plans structurants existent (V5 NX46, V61.2, V7.4, plan A→Z, etc.).
+- Couverture **partielle** des sous-dossiers de versions notebook: plusieurs dossiers versions ne possèdent pas de fichier plan dédié.
+
+### 5.2 Dossiers sans plan/roadmap dédié (écart gouvernance)
+- `notebook-version-NX47-V102`
+- `notebook-version-NX47-V107`
+- `notebook-version-NX47-V140`
+- `notebook-version-NX47-V140.1`
+- `notebook-version-NX47-V144`
+- `notebook-version-NX47-V144.1`
+- `notebook-version-NX47-V61.1`
+- `notebook-version-NX47-score-0.387-V61`
+
+➡️ Recommandation: ajouter un mini `PLAN_*.md` standardisé par dossier version (objectif, paramètres, résultat, score, anomalies, next actions).
+
+---
+
+## 6) Questions d’expert (résolues vs en attente)
+
+## 6.1 Résolues
+1. **Les runs V140.1/V144.1 corrigés finissent-ils sans erreur bloquante offline ?** → Oui.
+2. **Le format de soumission est-il volumique 3D valide ?** → Oui `(320,320,320)`.
+3. **V140.1 et V144.1 sont-ils réellement différents au niveau résultat ?** → Non, artefacts internes identiques (anomalie de différenciation).
+
+## 6.2 En attente (bloquants produit)
+1. **Quels sont les scores LB exacts de V140.1 et V144.1 ?** (non présents dans ces artefacts locaux).
+2. **Le binaire `0/255` impacte-t-il le score vs `0/1` dans votre pipeline de soumission actuel ?** (à trancher par A/B scoré).
+3. **Pourquoi la version interne reste `V139` dans les métadonnées des runs V140.1/V144.1 ?** (bug de tagging/version stamping à corriger).
+
+---
+
+## 7) Plan de suggestions détaillé (priorisé)
+
+### Priorité P0 — Fiabilité scientifique et traçabilité
+1. Corriger immédiatement le **version stamping** (`V140.1`/`V144.1`) dans tous les JSON/événements (`BOOT`, metadata, noms de fichiers).
+2. Ajouter un contrôle automatique “version attendue == version publiée”, fail si mismatch.
+3. Joindre systématiquement un fichier `score_tracking.json` (si score indisponible: statut explicite `pending_lb_score`).
+
+### Priorité P1 — Performance/score
+1. Faire un A/B strict `0/1` vs `0/255` sur même modèle + même seed.
+2. Consolider calibration seuil (ratio actif global + profil par slice) sur protocole reproductible.
+3. Garder V61.2 (0.387) comme baseline figée et comparer toutes les variantes avec protocole identique.
+
+### Priorité P2 — Gouvernance roadmap
+1. Créer un template unique de plan de version par dossier notebook.
+2. Rendre obligatoire une section “Questions ouvertes / réponses obtenues” dans chaque roadmap.
+3. Publier un tableau maître “version → score → statut → anomalies” synchronisé automatiquement.
+
+---
+
+## 8) Problèmes rencontrés pendant cette mission (notification sans omission)
+
+1. Au démarrage, aucun remote n’était configuré dans `.git/config` local; il a fallu réajouter `origin` avant fetch/pull.
+2. Dépendance locale `tifffile` absente pour l’inspection TIFF; installation réalisée pour permettre une analyse technique complète.
+3. Limite data: pas de score leaderboard V140.1/V144.1 inclus dans les artefacts inspectés.
+
+---
+
+## 9) Conclusion opérationnelle
+
+- ✅ La demande “reprendre depuis distant GitHub” a été exécutée.
+- ✅ Les dossiers **V140.1** et **V144.1** ont été inspectés en profondeur (ZIP/logs/metadata/hash).
+- ✅ Les deux versions corrigées finissent sans erreur offline et génèrent des soumissions 3D valides.
+- ⚠️ Anomalie majeure: elles embarquent des artefacts internes `V139` et sont quasi identiques en sortie.
+- ⚠️ Sans score LB V140.1/V144.1, impossible de conclure sur l’amélioration compétitive.
+

--- a/RAPPORT-VESUVIUS/RAPPORT_AUDIT_LUM_FORMAT_ET_MODELE_3D_C_20260219.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_AUDIT_LUM_FORMAT_ET_MODELE_3D_C_20260219.md
@@ -1,0 +1,108 @@
+# AUDIT EXPERT — Existence réelle du format `.lum` et modèle 3D côté LUM VORAX C
+
+Date: 2026-02-19
+
+## 0) Statut d’avancement (live)
+- ✅ Étape 1 terminée: inspection des modules C LUM/VORAX et dépendances directes.
+- ✅ Étape 2 terminée: vérification de l’intégration actuelle dans les versions actives Kaggle (V61.3, V7.5, V144.1, nx47_vesu_kernel_v2.py).
+- ✅ Étape 3 terminée: préparation d’un bootstrap dépendances `.whl` NX47 + LUM/VORAX réutilisable.
+- ⚠️ Étape 4 partielle: universalité "tous types de fichiers existants" non démontrée à 100% par le code actuel (voir limites).
+
+---
+
+## 1) Existence du format `.lum` (ou équivalent)
+
+## 1.1 Preuves d’existence
+- Module natif universel trouvé: `src/file_formats/lum_native_universal_format.c`.
+- Le header/versioning LUM est implémenté (`LUM_VORAX_NATIVE`, version majeure/mineure configurable).
+- Gestionnaire de fichier universel présent (`lum_universal_file_create`) avec checksum CRC32 et métaheader.
+
+## 1.2 Couverture de types de contenu
+Le module expose des types de contenus configurables:
+- texte, json, csv,
+- image RGB/RGBA/GRAY,
+- audio PCM,
+- vidéo,
+- neural weights,
+- binary blob,
+- lum native.
+
+=> Conclusion: **le format `.lum` existe bien** et vise un cadre universel multi-contenu.
+
+## 1.3 Limite objective
+Le fait d’énumérer plusieurs types ne prouve pas “décodage/encodage universel complet pour tous formats existants”.
+- Il faut des tests de conformité format par format (corpus + roundtrip + fuzzing + perfs).
+
+---
+
+## 2) Existence du modèle/traitement 3D côté C
+
+## 2.1 Ce qui est présent
+- Noyau LUM/VORAX C très développé (allocation, fusion/split, opérations SIMD, forensic logging).
+- Conversions binaires bit-level vers groupes LUM présentes (`binary_lum_converter.c`).
+
+## 2.2 Ce qui n’est pas explicitement démontré
+- Pas de module C dédié explicitement nommé “3D volume segmentation Vesuvius” dans le périmètre inspecté.
+- Les structures actuelles manipulent surtout des groupes LUM abstraits, pas un pipeline volumique TIFF 3D Kaggle prêt-à-l’emploi.
+
+=> Conclusion: **moteur C puissant présent**, mais **chaîne 3D Vesuvius C end-to-end non démontrée telle quelle**.
+
+---
+
+## 3) Intégration réelle actuelle dans les versions Kaggle
+
+## 3.1 V7.5 / V144.1 / V61.3
+- Forensic et calibration présents (surtout V7.5/V144.1).
+- Pipeline `.lum` natif non branché explicitement en production Kaggle dans ces versions.
+
+## 3.2 nx47_vesu_kernel_v2.py (nouvelle base retravaillée)
+- suppression du fallback synthétique,
+- ingestion TIFF réelle,
+- roundtrip `.lum` Python réel (header + checksum),
+- multi-seuil progressif 3D,
+- bridge C optionnel via `ctypes`, sans casser l’exécution Python pure.
+
+---
+
+## 4) Problèmes rencontrés pendant l’audit
+
+1. Périmètre très large multi-langages: impossible de certifier “100% universel” sans batterie de tests dédiée par format.
+2. Artefacts Kaggle n’embarquent pas tous les benchmarks de roundtrip `.lum` nécessaires à la preuve finale.
+3. Côté notebook, l’activation C dépend de la disponibilité `.so`/toolchain, d’où nécessité d’un fallback Python robuste.
+
+---
+
+## 5) Actions d’expert ajoutées (ce qui manquait)
+
+## 5.1 Dépendances `.whl` activables dans chaque notebook
+- Ajout d’un bootstrap réutilisable:
+  - `RAPPORT-VESUVIUS/src_vesuvius/lum_vorax_kaggle_bootstrap.py`
+- Il installe en offline depuis:
+  - `nx47-dependencies` existant,
+  - `lum-vorax-dependencies` (nouveau dataset attendu).
+
+## 5.2 Préparation interop C optionnelle
+- Bootstrap inclut compilation best-effort `.so` (si gcc et sources présents), sinon fallback Python.
+
+## 5.3 Alignement versions actives
+- v7.5 et v61.2: `install_offline` élargi pour chercher aussi `lum-vorax-dependencies`.
+- nx47_vesu_kernel_v2.py: pipeline renforcé sans placeholders de données synthétiques.
+
+---
+
+## 6) Questions critiques à débloquer maintenant
+
+1. Quel corpus officiel de formats doit être certifié “universel” en priorité (top 10) ?
+2. Quel SLA de roundtrip `.lum` (fidélité/perte/taille/temps) est acceptable ?
+3. Sur Kaggle, veut-on mode C obligatoire ou C optionnel + Python garanti ?
+4. Quelle baseline densité cible par version doit devenir garde-fou de release ?
+
+---
+
+## 7) Verdict
+
+- Oui, un module `.lum` existe bien et il est sérieux.
+- Non, l’universalité absolue n’est pas prouvée à 100% sans campagne de tests exhaustive.
+- Le 3D C “générique VORAX” existe partiellement via primitives, mais pas encore validé comme pipeline Vesuvius 3D complet branché partout.
+- Les bases techniques pour industrialiser l’activation dépendances `.whl` + pont Python/C sont maintenant prêtes.
+

--- a/RAPPORT-VESUVIUS/RAPPORT_MAJ_SCORES_V75_V1441_ANALYSE_DENSITE_20260219.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_MAJ_SCORES_V75_V1441_ANALYSE_DENSITE_20260219.md
@@ -1,0 +1,128 @@
+# MISE À JOUR ANALYSE — Scores Kaggle récents V7.5 vs V144.1 + causes probables de baisse
+
+Date: 2026-02-19  
+Contexte score communiqué (capture utilisateur):
+- `nx47-vesu-kernel-new-v144.1` : **0.269** (public score)
+- `nx46_vesuvius_core_kaggle_ready` (v7.5/Version 14) : **0.303** (public score)
+- Baseline antérieure de référence: `V61.2` = **0.387**
+
+---
+
+## 1) Faits techniques vérifiés dans les artefacts offline
+
+## 1.1 V144.1 (NX47)
+- `results.zip` contient `submission.zip` + `v139_execution_*.json` + forensic/memory/roadmap.
+- TIFF soumission:
+  - shape `(320,320,320)`
+  - `uint8`
+  - plage `0..255`
+  - moyenne `15.3`
+- Densité binaire équivalente (normalisée): `15.3 / 255 = 0.0600` (**6.00%** de voxels actifs)
+- Stats globales clés:
+  - `train_pair_count_discovered=786`
+  - `train_pair_coverage_pct=4.0712%` (très faible)
+  - `active_neurons_start_total=0`, `mid=6`, `end=6`
+  - `val_f1_mean_supervised=0.0`, `val_iou_mean_supervised=0.0`
+  - `elapsed_total_s≈2608.67s`
+
+## 1.2 V7.5 (NX46)
+- `results.zip` contient `state.json`, `metrics.csv`, `merkle_chain.log`, `bit_capture.log`, `submission.zip`.
+- TIFF soumission:
+  - shape `(320,320,320)`
+  - `uint8`
+  - plage `0..1`
+  - moyenne `0.02341796875` (**2.3418%** de voxels actifs)
+- `state.json` clés:
+  - `pipeline_status=success`
+  - `active_neurons=1,257,219`
+  - `train_items_total=786`, `train_items_with_labels=512`
+  - `cpu_total_ns=1,646,986,070,720`
+  - `submission_format_profile=kaggle_v8_5_style_zip_lzw_3d_uint8_0_1`
+- `metrics.csv` (513 lignes) montre au dernier fragment d’inférence:
+  - `ink_ratio=0.02341797` (aligné avec le TIFF final)
+
+## 1.3 Baseline V61.2 (référence scorée 0.387)
+- TIFF soumission:
+  - shape `(320,320,320)`
+  - `uint8`
+  - plage `0..1`
+  - moyenne `0.1225645447` (**12.256%** de voxels actifs)
+
+---
+
+## 2) Diagnostic comparatif “pourquoi ça n’évolue pas / pourquoi ça baisse”
+
+## 2.1 Signal principal: sous-prédiction de densité (under-segmentation)
+Comparaison densité de voxels prédits “ink”:
+- V61.2: **12.256%** (score 0.387)
+- V144.1: **6.000%** (score 0.269)
+- V7.5: **2.342%** (score 0.303)
+
+Lecture experte:
+- V7.5 et V144.1 sont beaucoup plus conservatrices que V61.2.
+- Si le GT réel contient plus d’encre que ce qui est prédit, le rappel chute fortement.
+- En segmentation Fβ/F1 orientée Kaggle, cette sous-densité peut dégrader fortement le score public.
+
+## 2.2 V144.1: apprentissage “actif” mais qualité val interne nulle
+- Les logs montrent un vrai pipeline supervisé (samples/epochs/hyperparams).
+- Mais `val_f1/val_iou` restent à 0.0.
+
+Hypothèse forte:
+- la calibration/thresholding final compense partiellement en sortie, mais l’apprentissage interne ne généralise pas correctement.
+- Le faible `train_pair_coverage_pct` suggère que la couverture effective d’apprentissage est insuffisante.
+
+## 2.3 V7.5: instrumentation excellente, calibration trop stricte
+- V7.5 a une très bonne traçabilité système (state/metrics/merkle), format conforme 3D 0/1.
+- Mais `ink_ratio` final à ~2.34% est très bas, indiquant une politique de sélection trop sévère.
+
+Conclusion comparative:
+- V7.5 semble “propre format + propre forensic”, mais trop conservatrice sur la détection.
+- V144.1 semble “pipeline plus lourd”, mais avec validation interne non convaincante.
+
+---
+
+## 3) Questions critiques à poser maintenant (les bonnes questions)
+
+1. Pourquoi V144.1 annonce-t-elle encore `version: NX47 V139` dans ses artefacts ?
+2. Pourquoi la couverture train effective V144.1 est-elle ~4.07% alors que 786 paires sont découvertes ?
+3. Quel est le couple `precision/recall` exact pour V7.5 et V144.1 (pas seulement score global) ?
+4. Quelle densité cible optimale de sortie (`ink_ratio`) maximise LB sur validation locale ?
+5. Quel seuil provoque le passage de 2.34% (V7.5) vers une zone 6–12% (plus proche V61.2) ?
+6. Le profil 0/255 de V144.1 affecte-t-il le post-processing/lecture aval malgré la normalisation implicite ?
+7. Sur V144.1, pourquoi 6 neurones actifs au final alors que la complexité visuelle du volume est élevée ?
+8. L’ablation `mutation_applied=False` / `pruning_applied=True` est-elle trop agressive pour le rappel ?
+9. Quelle différence exacte de distribution des probabilités entre V61.2, V7.5, V144.1 ?
+10. Les tranches z à faible signal sont-elles systématiquement coupées par la calibration actuelle ?
+
+---
+
+## 4) Plan d’actions concret (pour remonter le score)
+
+## P0 (immédiat)
+- Ajouter un export standard `density_diagnostics.json` par run:
+  - `ink_ratio_global`, `ink_ratio_by_slice`, percentiles probas, seuil final.
+- Forcer un A/B de calibration avec 3 cibles de densité:
+  - cible basse: 0.03
+  - cible médiane: 0.06
+  - cible haute: 0.10-0.12
+- Corriger le version stamping V144.1 (`v139_*` -> version réelle).
+
+## P1 (1 à 2 itérations)
+- V144.1: augmenter couverture train effective et tracer `train_pair_used_count` réel.
+- V7.5: desserrer `threshold_quantile` et `score_blend_3d_weight` pour récupérer du recall.
+- Ajouter benchmark “par tranche z” pour repérer les zones où le modèle coupe trop.
+
+## P2 (stabilisation)
+- Standardiser un tableau comparatif obligatoire à chaque version:
+  - score LB, densité globale, densité par tranche, précision/recall estimés, runtime, conformité ZIP.
+- Établir une règle de non-régression:
+  - on ne pousse pas une version si densité sort de la plage validée historiquement.
+
+---
+
+## 5) Conclusion nette
+
+- Les deux versions soumettent correctement, mais les scores récents montrent un recul vs V61.2.
+- Le facteur le plus tangible dans les artefacts est la **baisse de densité prédite** (sous-segmentation), surtout V7.5.
+- Pour progresser, il faut prioriser un protocole strict de calibration densité + couverture d’apprentissage + tableaux per-slice.
+

--- a/RAPPORT-VESUVIUS/RAPPORT_STRATEGIE_MULTI_SEUIL_LUM_VORAX_INTEGRATION_V613_V75_V1441_20260219.md
+++ b/RAPPORT-VESUVIUS/RAPPORT_STRATEGIE_MULTI_SEUIL_LUM_VORAX_INTEGRATION_V613_V75_V1441_20260219.md
@@ -1,0 +1,139 @@
+# RAPPORT STRATÉGIQUE — Intégration multi-seuil + pipeline `.lum` (V61.3 / V7.5 / V144.1)
+
+Date: 2026-02-19
+
+## 0) Expertises mobilisées (temps réel)
+1. Computer Vision 3D (Vesuvius segmentation volumique).
+2. MLOps Kaggle (conformité submission ZIP/TIFF, calibration score-driven).
+3. Forensic engineering (logs, merkle, memory tracking, traçabilité).
+4. Systèmes bas niveau C/C++ et interop Python (ctypes/subprocess/packaging Kaggle).
+5. Ingénierie format de données (`.tif/.zip/.json` vers format canonique `.lum`).
+
+---
+
+## 1) Analyse de ta proposition (multi-seuil progressif + accumulation couches 3D)
+
+Ta proposition est correcte et techniquement pertinente.
+
+### Pourquoi c’est solide
+- Commencer avec des seuils bas puis monter progressivement permet de capter d’abord les zones à haute sensibilité (recall), puis de nettoyer les faux positifs sur des couches plus strictes.
+- Ce mécanisme peut être implémenté comme une **fusion hiérarchique de masques 3D**:
+  1) masque_base (seuil bas),
+  2) masque_intermédiaire,
+  3) masque_haut,
+  4) nettoyage morphologique/consensus slice-wise,
+  5) accumulation pondérée finale contrainte dans la plage densité cible.
+
+### Risque à surveiller
+- Si l’accumulation n’est pas contrainte, elle peut sur-segmenter; il faut donc un garde-fou `density_target_range` + `precision floor`.
+
+---
+
+## 2) Constats factuels après lecture des sources et artefacts
+
+## 2.1 Densité sortie 3D (offline)
+- V61.3: TIFF `(320,320,320)` en `0/1`, moyenne `0.1225645` (≈12.256%).
+- V7.5: TIFF `(320,320,320)` en `0/1`, moyenne `0.023418` (≈2.342%).
+- V144.1: TIFF `(320,320,320)` en `0/255`, moyenne `15.3`, soit densité normalisée ≈`6.00%`.
+
+=> Le signal de baisse reste cohérent avec une sous-densité forte sur V7.5 et moyenne sur V144.1.
+
+## 2.2 Lecture code versions (résumé exécutable)
+- V144.1 notebook:
+  - ~2017 lignes code, 29 fonctions, 1 classe.
+  - forensics présents (merkle/memory/logs), termes seuil/calibration nombreux.
+- V7.5 (py + notebook):
+  - ~1010 lignes, 26 fonctions.
+  - calibration présente (`threshold_quantile`, `score_blend_3d_weight`, `z_smoothing`).
+  - format submission 3D `0/1` déjà aligné.
+- V61.3 notebook:
+  - plus compact, moins de logique forensic détaillée.
+
+## 2.3 Technologies LUM VORAX détectées et état d’intégration
+- Modules C/C++ disponibles dans repo:
+  - `src/binary/binary_lum_converter.c`
+  - `src/file_formats/lum_native_universal_format.c`
+  - `src/vorax/vorax_operations.c`
+  - + autres modules lum/parser/logger/spatial.
+- Dans les versions Kaggle auditées (V61.3/V7.5/V144.1):
+  - intégration native `.lum` **non active** (pas de pipeline `.lum` opérationnel explicite).
+  - intégration forensic/merkle **déjà active** surtout dans V7.5 et V144.1.
+
+---
+
+## 3) Réponse directe: “tout convertir en `.lum` pour éviter les mauvaises conversions”
+
+C’est faisable, avec deux niveaux:
+
+### Niveau A (immédiat 100% Python, Kaggle-safe)
+- Définir un conteneur `.lum` Python (binaire simple) avec:
+  - header (version, dtype, shape, endian, checksum),
+  - payload volumique brut compressé (zlib/lz4 selon dispo),
+  - metadata JSON embarquée.
+- Pipeline:
+  1) lecture TIFF/ZIP,
+  2) conversion vers `.lum`,
+  3) calculs VORAX sur `.lum`,
+  4) reconversion vers TIFF submission.
+
+### Niveau B (interop C/C++ optionnelle)
+- Compiler les modules C `lum/vorax` en `.so` dans Kaggle (si toolchain dispo), puis appel Python via `ctypes`.
+- Fallback obligatoire pur Python si compilation indisponible.
+
+### Décision pragmatique
+- Démarrer par Niveau A (zéro blocage d’environnement), puis brancher Niveau B en accélération progressive.
+
+---
+
+## 4) Parties qui bénéficient déjà de la techno LUM VORAX
+
+1. **Traçabilité/forensic** (merkle, logs détaillés) : déjà utilisable comme socle VORAX audit.
+2. **Calibration paramétrique** (v7.5) : déjà compatible avec stratégie multi-seuil.
+3. **Validation format Kaggle** : déjà en place (v7.5, v144.1).
+
+Manque principal:
+- couche de normalisation canonique de données `.lum` avant scoring.
+
+---
+
+## 5) Problèmes rencontrés durant cette mission (sans omission)
+
+1. Le périmètre “lire totalité de tous codes multi-langages” est immense; audit focalisé sur versions actives + modules LUM/VORAX cœur pour rester opérationnel.
+2. Dépendances Python d’inspection (`nbformat`, `tifffile`, `imagecodecs`) absentes au départ dans l’environnement; installation nécessaire.
+3. Les scores LB détaillés par configuration de seuil ne sont pas dans les artefacts offline, seulement les scores finals partagés.
+
+---
+
+## 6) Plan d’intégration mis à jour (version par version)
+
+## V61.3
+- Ajouter calibration multi-seuil hiérarchique (low→mid→high).
+- Ajouter export diagnostics densité par tranche.
+- Ajouter option conversion `.lum` (Python d’abord).
+
+## V7.5
+- Conserver base actuelle (déjà conforme 3D/0-1).
+- Ajouter accumulation multi-seuil + contrainte densité cible concurrente.
+- Ajouter mode `.lum` canonique en entrée/sortie intermédiaire.
+
+## V144.1
+- Harmoniser `0/255` vers binaire canonique configurable (`0/1` par défaut).
+- Corriger version stamping interne.
+- Ajouter contrôle coverage train pair + pipeline multi-seuil.
+
+---
+
+## 7) Questions expertes prioritaires (déblocage)
+1. Quelle plage densité cible maximise LB pour chaque version (au lieu d’une plage unique globale) ?
+2. Quel gain LB apporte `multi-threshold accumulation` vs seuil unique à budget runtime constant ?
+3. Quelle partie des faux positifs provient des tranches profondes z (profil z-wise) ?
+4. Quel est le coût exact du passage `.tif -> .lum -> .tif` en Kaggle CPU-only ?
+5. L’implémentation C `.so` apporte-t-elle un gain significatif vs Python pur dans les limites Kaggle ?
+
+---
+
+## 8) Verdict
+- Ton analyse est juste: stratégie multi-seuil progressive + accumulation 3D est la meilleure piste immédiate.
+- L’intégration `.lum` est faisable et utile pour stabiliser les conversions, à condition de commencer par un standard Python exécutable partout.
+- Les plans versions doivent explicitement inclure: `density target`, `z-wise diagnostics`, `fallback Python`, `interop C optional`.
+

--- a/RAPPORT-VESUVIUS/analysis_v1401_v1441_deep_audit.json
+++ b/RAPPORT-VESUVIUS/analysis_v1401_v1441_deep_audit.json
@@ -1,340 +1,121 @@
 {
-  "missing_dirs": [
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V140.1",
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V144.1"
-  ],
-  "datasets": {
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V140": {
-      "files": [
-        {
-          "name": "nx47-vesu-kernel-new-v140.ipynb",
-          "size": 4440884
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v140.py",
-          "size": 97717
-        },
-        {
-          "name": "qFu5IalT.txt",
-          "size": 4087652
-        },
-        {
-          "name": "results.zip",
-          "size": 2327166
-        }
-      ],
-      "zips": {
-        "results.zip": {
-          "member_count": 7,
-          "members": [
-            "submission.zip",
-            "v139_execution_logs.json",
-            "v139_execution_metadata.json",
-            "v139_forensic_analysis_report.json",
-            "v139_memory_tracker.json",
-            "v139_roadmap_realtime.json",
-            "v139_ultra_authentic_360_merkle.jsonl"
-          ],
-          "tif_count": 0,
-          "tif_meta": [],
-          "nested_submission": {
-            "name": "submission.zip",
-            "member_count": 1,
-            "tif_count": 1,
-            "tifs": [
-              "1407735.tif"
-            ],
-            "sample": {
-              "name": "1407735.tif",
-              "shape": [
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 1,
-              "nonzero": 6144
-            }
-          }
-        }
+  "notebook-version-NX47-V140.1": {
+    "exists": true,
+    "files": [
+      {
+        "file": "notebook-version-NX47-V140.1/Yl-2S3gi.txt",
+        "size": 4086299,
+        "lines": 4080,
+        "errors": 0,
+        "warnings": 6,
+        "has_score_0387": true,
+        "has_offline": false,
+        "tail": [
+          "2608.8s 4066 {\"ts_ns\": 1771445077701006987, \"event\": \"GLOBAL_STATS\", \"files_processed\": 1, \"slices_processed\": 320, \"pixels_processed\": 32768000, \"pixels_anchor_detected\": 0, \"pixels_papyrus_without_anchor\": 6144, \"materials_detected\": 933, \"patterns_detected\": 933, \"golden_nonce_detected\": 11, \"unknown_discoveries\": 0, \"anomalies_detected\": 52, \"calc_ops_estimated\": 27852800, \"active_neurons_start_total\": 0, \"active_neurons_mid_total\": 6, \"active_neurons_end_total\": 6, \"meta_neuron_candidates\": 45, \"mutation_events\": 0, \"pruning_events\": 1, \"f1_ratio_curve_best_ratio\": 0.20591836734693877, \"f1_ratio_curve_best_f1\": 0.686275490593166, \"files_supervised_mode\": 1, \"files_autonomous_fallback\": 0, \"val_f1_mean_supervised\": 0.0, \"val_iou_mean_supervised\": 0.0, \"best_threshold_mean_supervised\": 0.35, \"unet_25d_status\": \"ok\", \"unet_25d_best_fbeta\": 0.0, \"forensic_report_generated\": true, \"probability_max_observed\": 0.1458509862422943, \"probability_mean_observed\": 0.09743015468120575, \"probability_std_observed\": 0.035574305802583694, \"learning_percent_real\": 100.0, \"reasoning_trace_events\": 4047, \"train_pair_count_discovered\": 786, \"train_pair_coverage_pct\": 4.071246819338422, \"calc_per_sec_global\": 10750.924617446291, \"elapsed_total_s\": 2590.7353079940003, \"ratio_selected_mean\": 0.205, \"signature\": \"6dd86a2b8e4511c951b654aea50d6e14b1931e172ba07079d7bb41520d5f16acaac73c4d3f4e2e8e974151ff94c642d1259ea5d9a3b44023aae21dace51d5ca7\", \"prev_merkle\": \"f94733c6046495bf940d6ba10ddfbca55deda89a1deb47f1924014bc6d698d5c876da768533341f615bdfa2fa10c4a7076c6fc28d4d5dfb82fd0840784a6f564\", \"merkle\": \"7dd3597e5ff3d42513b074a04c14c54149b5f889827ee9b08dcd0bc91fa88e4b16d63b1ee38b880c6fa36e9c9548ba81ddcb7b40fd9168b17680ad19bd5269f9\"}",
+          "2608.9s 4067 {\"ts_ns\": 1771445077731039307, \"event\": \"EXEC_COMPLETE\", \"submission\": \"/kaggle/working/submission.zip\", \"signature\": \"e78061ee8940bbf03bc30ac09f51d9537829845e8a298455fcc6735cdf55b43b486996bb5553ba9c8942e868086d1b9ff1bf47321db10dabedac9f3cde1f3962\", \"prev_merkle\": \"7dd3597e5ff3d42513b074a04c14c54149b5f889827ee9b08dcd0bc91fa88e4b16d63b1ee38b880c6fa36e9c9548ba81ddcb7b40fd9168b17680ad19bd5269f9\", \"merkle\": \"198d390d551dd45633045dbc52030c80211cad8ad63d7098698f17a3575bacbbbb329c40c476cf5f4d73ded521f5ea81ded3e2eba3ea9032812decc12a90d16f\"}",
+          "2609.0s 4068 READY: /kaggle/working/submission.zip",
+          "2614.0s 4069 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "2614.0s 4070 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "2614.2s 4071 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "2614.2s 4072 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "2614.8s 4073 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2614.8s 4074 warn(",
+          "2614.9s 4075 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "2616.4s 4076 [NbConvertApp] Writing 4440993 bytes to __notebook__.ipynb",
+          "2618.9s 4077 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2618.9s 4078 warn(",
+          "2618.9s 4079 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "2620.2s 4080 [NbConvertApp] Writing 5817592 bytes to __results__.html"
+        ]
       },
-      "log_summary": {
-        "qFu5IalT.txt": {
-          "traceback": 0,
-          "runtime_error": 0,
-          "exec_complete": 1,
-          "ready_submission": 1,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 1
-        }
-      }
-    },
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V144": {
-      "files": [
-        {
-          "name": "XIZfXSQO.txt",
-          "size": 4302
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v144.ipynb",
-          "size": 123940
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v144.log",
-          "size": 4302
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v144.py",
-          "size": 97717
-        },
-        {
-          "name": "results.zip",
-          "size": 370
-        }
-      ],
-      "zips": {
-        "results.zip": {
-          "member_count": 2,
-          "members": [
-            "logs_AIMO3/nx/NX46/audit.log",
-            "v139_ultra_authentic_360_merkle.jsonl"
-          ],
-          "tif_count": 0,
-          "tif_meta": []
-        }
+      {
+        "file": "notebook-version-NX47-V140.1/nx47-vesu-kernel-new-v140-1.ipynb",
+        "size": 4441025
       },
-      "log_summary": {
-        "XIZfXSQO.txt": {
-          "traceback": 2,
-          "runtime_error": 4,
-          "exec_complete": 0,
-          "ready_submission": 0,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 0
-        },
-        "nx47-vesu-kernel-new-v144.log": {
-          "traceback": 2,
-          "runtime_error": 4,
-          "exec_complete": 0,
-          "ready_submission": 0,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 0
-        }
-      }
-    },
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V61.2": {
-      "files": [
-        {
-          "name": "BRzSoZeY.txt",
-          "size": 6984
-        },
-        {
-          "name": "PLAN_V61_2_FEUILLE_DE_ROUTE_COMPLETE.md",
-          "size": 2578
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v61-2.ipynb",
-          "size": 18268
-        },
-        {
-          "name": "nx47-vesu-kernel-new-v61-2.log",
-          "size": 6984
-        },
-        {
-          "name": "nx47-vesuvius-challenge-surface-detection-v61.2.py",
-          "size": 8949
-        },
-        {
-          "name": "results.zip",
-          "size": 4703302
-        }
-      ],
-      "zips": {
-        "results.zip": {
-          "member_count": 5,
-          "members": [
-            "final_logs/forensic_audit_1771420660.log",
-            "nx47_vesuvius/submission.zip",
-            "submission.zip",
-            "v28_forensic_logs/forensic_v28_cdffa7284d7d4c78.log",
-            "v28_forensic_logs/wal_v28_cdffa7284d7d4c78.bin"
-          ],
-          "tif_count": 0,
-          "tif_meta": [],
-          "nested_submission": {
-            "name": "nx47_vesuvius/submission.zip",
-            "member_count": 1,
-            "tif_count": 1,
-            "tifs": [
-              "1407735.tif"
-            ],
-            "sample": {
-              "name": "1407735.tif",
-              "shape": [
-                320,
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 1,
-              "nonzero": 4016195
-            }
-          }
-        }
+      {
+        "file": "notebook-version-NX47-V140.1/nx47-vesu-kernel-new-v140-1.log",
+        "size": 4086299,
+        "lines": 4080,
+        "errors": 0,
+        "warnings": 6,
+        "has_score_0387": true,
+        "has_offline": false,
+        "tail": [
+          "2608.8s 4066 {\"ts_ns\": 1771445077701006987, \"event\": \"GLOBAL_STATS\", \"files_processed\": 1, \"slices_processed\": 320, \"pixels_processed\": 32768000, \"pixels_anchor_detected\": 0, \"pixels_papyrus_without_anchor\": 6144, \"materials_detected\": 933, \"patterns_detected\": 933, \"golden_nonce_detected\": 11, \"unknown_discoveries\": 0, \"anomalies_detected\": 52, \"calc_ops_estimated\": 27852800, \"active_neurons_start_total\": 0, \"active_neurons_mid_total\": 6, \"active_neurons_end_total\": 6, \"meta_neuron_candidates\": 45, \"mutation_events\": 0, \"pruning_events\": 1, \"f1_ratio_curve_best_ratio\": 0.20591836734693877, \"f1_ratio_curve_best_f1\": 0.686275490593166, \"files_supervised_mode\": 1, \"files_autonomous_fallback\": 0, \"val_f1_mean_supervised\": 0.0, \"val_iou_mean_supervised\": 0.0, \"best_threshold_mean_supervised\": 0.35, \"unet_25d_status\": \"ok\", \"unet_25d_best_fbeta\": 0.0, \"forensic_report_generated\": true, \"probability_max_observed\": 0.1458509862422943, \"probability_mean_observed\": 0.09743015468120575, \"probability_std_observed\": 0.035574305802583694, \"learning_percent_real\": 100.0, \"reasoning_trace_events\": 4047, \"train_pair_count_discovered\": 786, \"train_pair_coverage_pct\": 4.071246819338422, \"calc_per_sec_global\": 10750.924617446291, \"elapsed_total_s\": 2590.7353079940003, \"ratio_selected_mean\": 0.205, \"signature\": \"6dd86a2b8e4511c951b654aea50d6e14b1931e172ba07079d7bb41520d5f16acaac73c4d3f4e2e8e974151ff94c642d1259ea5d9a3b44023aae21dace51d5ca7\", \"prev_merkle\": \"f94733c6046495bf940d6ba10ddfbca55deda89a1deb47f1924014bc6d698d5c876da768533341f615bdfa2fa10c4a7076c6fc28d4d5dfb82fd0840784a6f564\", \"merkle\": \"7dd3597e5ff3d42513b074a04c14c54149b5f889827ee9b08dcd0bc91fa88e4b16d63b1ee38b880c6fa36e9c9548ba81ddcb7b40fd9168b17680ad19bd5269f9\"}",
+          "2608.9s 4067 {\"ts_ns\": 1771445077731039307, \"event\": \"EXEC_COMPLETE\", \"submission\": \"/kaggle/working/submission.zip\", \"signature\": \"e78061ee8940bbf03bc30ac09f51d9537829845e8a298455fcc6735cdf55b43b486996bb5553ba9c8942e868086d1b9ff1bf47321db10dabedac9f3cde1f3962\", \"prev_merkle\": \"7dd3597e5ff3d42513b074a04c14c54149b5f889827ee9b08dcd0bc91fa88e4b16d63b1ee38b880c6fa36e9c9548ba81ddcb7b40fd9168b17680ad19bd5269f9\", \"merkle\": \"198d390d551dd45633045dbc52030c80211cad8ad63d7098698f17a3575bacbbbb329c40c476cf5f4d73ded521f5ea81ded3e2eba3ea9032812decc12a90d16f\"}",
+          "2609.0s 4068 READY: /kaggle/working/submission.zip",
+          "2614.0s 4069 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "2614.0s 4070 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "2614.2s 4071 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "2614.2s 4072 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "2614.8s 4073 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2614.8s 4074 warn(",
+          "2614.9s 4075 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "2616.4s 4076 [NbConvertApp] Writing 4440993 bytes to __notebook__.ipynb",
+          "2618.9s 4077 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2618.9s 4078 warn(",
+          "2618.9s 4079 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "2620.2s 4080 [NbConvertApp] Writing 5817592 bytes to __results__.html"
+        ]
       },
-      "log_summary": {
-        "BRzSoZeY.txt": {
-          "traceback": 0,
-          "runtime_error": 0,
-          "exec_complete": 1,
-          "ready_submission": 1,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 0
-        },
-        "nx47-vesu-kernel-new-v61-2.log": {
-          "traceback": 0,
-          "runtime_error": 0,
-          "exec_complete": 1,
-          "ready_submission": 1,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 0
-        }
-      }
-    },
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/output_logs_vesuvius/v7.4-outlput-logs--nx46-vesuvius-core-kaggle-ready": {
-      "files": [
-        {
-          "name": "nx46-vesuvius-core-kaggle-ready.ipynb",
-          "size": 105461
-        },
-        {
-          "name": "results.zip",
-          "size": 345193
-        }
-      ],
-      "zips": {
-        "results.zip": {
-          "member_count": 15,
-          "members": [
-            "nx46_vesuvius/logs/RkF4XakI.txt",
-            "nx46_vesuvius/logs/UJxLRsEE.txt",
-            "nx46_vesuvius/logs/bit_capture.log",
-            "nx46_vesuvius/logs/dataset_discovery_inventory.json",
-            "nx46_vesuvius/logs/forensic_ultra.log",
-            "nx46_vesuvius/logs/merkle_chain.log",
-            "nx46_vesuvius/logs/metrics.csv",
-            "nx46_vesuvius/logs/nx-46-vesuvius-core.log",
-            "nx46_vesuvius/logs/nx46-vesuvius-core-kaggle-ready.log",
-            "nx46_vesuvius/logs/state.json",
-            "nx46_vesuvius/material_maps/1407735.tif",
-            "nx46_vesuvius/native_training_manifest.json",
-            "nx46_vesuvius/submission.zip",
-            "submission.zip",
-            "submission_masks/1407735.tif"
-          ],
-          "tif_count": 2,
-          "tif_meta": [
+      {
+        "file": "notebook-version-NX47-V140.1/results.zip",
+        "size": 2334752,
+        "zip": {
+          "path": "RAPPORT-VESUVIUS/notebook-version-NX47-V140.1/results.zip",
+          "entries": [
             {
-              "name": "nx46_vesuvius/material_maps/1407735.tif",
-              "shape": [
-                1,
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 3,
-              "nonzero": 66783
+              "name": "submission.zip",
+              "size": 21842,
+              "compress_size": 13210
             },
             {
-              "name": "submission_masks/1407735.tif",
-              "shape": [
-                320,
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 1,
-              "nonzero": 767360
-            }
-          ],
-          "nested_submission": {
-            "name": "nx46_vesuvius/submission.zip",
-            "member_count": 1,
-            "tif_count": 1,
-            "tifs": [
-              "1407735.tif"
-            ],
-            "sample": {
-              "name": "1407735.tif",
-              "shape": [
-                320,
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 1,
-              "nonzero": 767360
-            }
-          }
-        }
-      },
-      "log_summary": {}
-    },
-    "RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/output_logs_vesuvius/v7.5-outlput-logs--nx46-vesuvius-core-kaggle-ready": {
-      "files": [
-        {
-          "name": "AdmY-IOr.txt",
-          "size": 54070
-        },
-        {
-          "name": "nx46-vesuvius-core-kaggle-ready.ipynb",
-          "size": 106924
-        },
-        {
-          "name": "results.zip",
-          "size": 345131
-        }
-      ],
-      "zips": {
-        "results.zip": {
-          "member_count": 15,
-          "members": [
-            "nx46_vesuvius/logs/RkF4XakI.txt",
-            "nx46_vesuvius/logs/UJxLRsEE.txt",
-            "nx46_vesuvius/logs/bit_capture.log",
-            "nx46_vesuvius/logs/dataset_discovery_inventory.json",
-            "nx46_vesuvius/logs/forensic_ultra.log",
-            "nx46_vesuvius/logs/merkle_chain.log",
-            "nx46_vesuvius/logs/metrics.csv",
-            "nx46_vesuvius/logs/nx-46-vesuvius-core.log",
-            "nx46_vesuvius/logs/nx46-vesuvius-core-kaggle-ready.log",
-            "nx46_vesuvius/logs/state.json",
-            "nx46_vesuvius/material_maps/1407735.tif",
-            "nx46_vesuvius/native_training_manifest.json",
-            "nx46_vesuvius/submission.zip",
-            "submission.zip",
-            "submission_masks/1407735.tif"
-          ],
-          "tif_count": 2,
-          "tif_meta": [
-            {
-              "name": "nx46_vesuvius/material_maps/1407735.tif",
-              "shape": [
-                1,
-                320,
-                320
-              ],
-              "dtype": "uint8",
-              "min": 0,
-              "max": 3,
-              "nonzero": 66783
+              "name": "v139_execution_logs.json",
+              "size": 3537498,
+              "compress_size": 868945
             },
             {
-              "name": "submission_masks/1407735.tif",
+              "name": "v139_execution_metadata.json",
+              "size": 261992,
+              "compress_size": 85025
+            },
+            {
+              "name": "v139_forensic_analysis_report.json",
+              "size": 1528,
+              "compress_size": 1130
+            },
+            {
+              "name": "v139_memory_tracker.json",
+              "size": 32082,
+              "compress_size": 8168
+            },
+            {
+              "name": "v139_roadmap_realtime.json",
+              "size": 980,
+              "compress_size": 412
+            },
+            {
+              "name": "v139_ultra_authentic_360_merkle.jsonl",
+              "size": 4034114,
+              "compress_size": 1356822
+            }
+          ],
+          "nested": [
+            {
+              "name": "submission.zip",
+              "entries": [
+                {
+                  "name": "1407735.tif",
+                  "size": 1489920,
+                  "compress_size": 21722
+                }
+              ]
+            }
+          ],
+          "tiffs": [
+            {
+              "container": "submission.zip",
+              "name": "1407735.tif",
               "shape": [
                 320,
                 320,
@@ -342,18 +123,270 @@
               ],
               "dtype": "uint8",
               "min": 0,
-              "max": 1,
-              "nonzero": 767360
+              "max": 255,
+              "mean": 15.3
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "notebook-version-NX47-V144.1": {
+    "exists": true,
+    "files": [
+      {
+        "file": "notebook-version-NX47-V144.1/nx47-vesu-kernel-new-v144-1.ipynb",
+        "size": 4441571
+      },
+      {
+        "file": "notebook-version-NX47-V144.1/nx47-vesu-kernel-new-v144-1.log",
+        "size": 4086850,
+        "lines": 4080,
+        "errors": 0,
+        "warnings": 6,
+        "has_score_0387": true,
+        "has_offline": false,
+        "tail": [
+          "2627.6s 4066 {\"ts_ns\": 1771445290735712237, \"event\": \"GLOBAL_STATS\", \"files_processed\": 1, \"slices_processed\": 320, \"pixels_processed\": 32768000, \"pixels_anchor_detected\": 0, \"pixels_papyrus_without_anchor\": 6144, \"materials_detected\": 933, \"patterns_detected\": 933, \"golden_nonce_detected\": 11, \"unknown_discoveries\": 0, \"anomalies_detected\": 52, \"calc_ops_estimated\": 27852800, \"active_neurons_start_total\": 0, \"active_neurons_mid_total\": 6, \"active_neurons_end_total\": 6, \"meta_neuron_candidates\": 45, \"mutation_events\": 0, \"pruning_events\": 1, \"f1_ratio_curve_best_ratio\": 0.20591836734693877, \"f1_ratio_curve_best_f1\": 0.686275490593166, \"files_supervised_mode\": 1, \"files_autonomous_fallback\": 0, \"val_f1_mean_supervised\": 0.0, \"val_iou_mean_supervised\": 0.0, \"best_threshold_mean_supervised\": 0.35, \"unet_25d_status\": \"ok\", \"unet_25d_best_fbeta\": 0.0, \"forensic_report_generated\": true, \"probability_max_observed\": 0.1458509862422943, \"probability_mean_observed\": 0.09743015468120575, \"probability_std_observed\": 0.035574305802583694, \"learning_percent_real\": 100.0, \"reasoning_trace_events\": 4047, \"train_pair_count_discovered\": 786, \"train_pair_coverage_pct\": 4.071246819338422, \"calc_per_sec_global\": 10676.993625822597, \"elapsed_total_s\": 2608.674405559, \"ratio_selected_mean\": 0.205, \"signature\": \"9b0c60b60049d3f5101121d274593d44bab949edbc9a3e4e37e4ec13d64a598166f0374a9bcef5cb423cbe54d73b23dba3f32e32bbb83ef52596bd2e14b26ca2\", \"prev_merkle\": \"026729c8a30411a13d5410ccc9d7e96a7bb28dc8be52a0288085336dc3950adb6e853a1c968255f4f4eea6aeda8b18f111bb4dce97869f173ff7c6ec821fbbd7\", \"merkle\": \"57fcccb0f9a958054a582c660c19bfb6328fbe38a6975fee632e48d208feae84649d0eab302694c47847af3d58f81b68fdf7ca10fad22c630623110fee5c5505\"}",
+          "2627.7s 4067 {\"ts_ns\": 1771445290768407535, \"event\": \"EXEC_COMPLETE\", \"submission\": \"/kaggle/working/submission.zip\", \"signature\": \"54ed09d8304f6f6a2edb5dc392d372890001d326bc84cb39a6572c4791cfd6bd2a321381fa4861ff8896d6a80cd0217311512059eb8a5d5c7ae3cdfefa662aff\", \"prev_merkle\": \"57fcccb0f9a958054a582c660c19bfb6328fbe38a6975fee632e48d208feae84649d0eab302694c47847af3d58f81b68fdf7ca10fad22c630623110fee5c5505\", \"merkle\": \"83666dfc1416407c09307901367640e99de68e8a96b58dcb5517b4d5b434421c694e220ae79817e59d2fd38f116bb1b71425476c5ebe1e3f2be34e55ba1de0d6\"}",
+          "2627.8s 4068 READY: /kaggle/working/submission.zip",
+          "2632.8s 4069 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "2632.8s 4070 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "2633.0s 4071 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "2633.0s 4072 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "2633.7s 4073 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2633.7s 4074 warn(",
+          "2633.7s 4075 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "2635.2s 4076 [NbConvertApp] Writing 4441539 bytes to __notebook__.ipynb",
+          "2637.8s 4077 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2637.8s 4078 warn(",
+          "2637.9s 4079 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "2639.2s 4080 [NbConvertApp] Writing 5818138 bytes to __results__.html"
+        ]
+      },
+      {
+        "file": "notebook-version-NX47-V144.1/results.zip",
+        "size": 2334760,
+        "zip": {
+          "path": "RAPPORT-VESUVIUS/notebook-version-NX47-V144.1/results.zip",
+          "entries": [
+            {
+              "name": "submission.zip",
+              "size": 21842,
+              "compress_size": 13210
+            },
+            {
+              "name": "v139_execution_logs.json",
+              "size": 3537498,
+              "compress_size": 868978
+            },
+            {
+              "name": "v139_execution_metadata.json",
+              "size": 261992,
+              "compress_size": 85028
+            },
+            {
+              "name": "v139_forensic_analysis_report.json",
+              "size": 1528,
+              "compress_size": 1130
+            },
+            {
+              "name": "v139_memory_tracker.json",
+              "size": 32082,
+              "compress_size": 8168
+            },
+            {
+              "name": "v139_roadmap_realtime.json",
+              "size": 980,
+              "compress_size": 412
+            },
+            {
+              "name": "v139_ultra_authentic_360_merkle.jsonl",
+              "size": 4034114,
+              "compress_size": 1356794
             }
           ],
-          "nested_submission": {
-            "name": "nx46_vesuvius/submission.zip",
-            "member_count": 1,
-            "tif_count": 1,
-            "tifs": [
-              "1407735.tif"
-            ],
-            "sample": {
+          "nested": [
+            {
+              "name": "submission.zip",
+              "entries": [
+                {
+                  "name": "1407735.tif",
+                  "size": 1489920,
+                  "compress_size": 21722
+                }
+              ]
+            }
+          ],
+          "tiffs": [
+            {
+              "container": "submission.zip",
+              "name": "1407735.tif",
+              "shape": [
+                320,
+                320,
+                320
+              ],
+              "dtype": "uint8",
+              "min": 0,
+              "max": 255,
+              "mean": 15.3
+            }
+          ]
+        }
+      },
+      {
+        "file": "notebook-version-NX47-V144.1/s0zulCMY.txt",
+        "size": 4086850,
+        "lines": 4080,
+        "errors": 0,
+        "warnings": 6,
+        "has_score_0387": true,
+        "has_offline": false,
+        "tail": [
+          "2627.6s 4066 {\"ts_ns\": 1771445290735712237, \"event\": \"GLOBAL_STATS\", \"files_processed\": 1, \"slices_processed\": 320, \"pixels_processed\": 32768000, \"pixels_anchor_detected\": 0, \"pixels_papyrus_without_anchor\": 6144, \"materials_detected\": 933, \"patterns_detected\": 933, \"golden_nonce_detected\": 11, \"unknown_discoveries\": 0, \"anomalies_detected\": 52, \"calc_ops_estimated\": 27852800, \"active_neurons_start_total\": 0, \"active_neurons_mid_total\": 6, \"active_neurons_end_total\": 6, \"meta_neuron_candidates\": 45, \"mutation_events\": 0, \"pruning_events\": 1, \"f1_ratio_curve_best_ratio\": 0.20591836734693877, \"f1_ratio_curve_best_f1\": 0.686275490593166, \"files_supervised_mode\": 1, \"files_autonomous_fallback\": 0, \"val_f1_mean_supervised\": 0.0, \"val_iou_mean_supervised\": 0.0, \"best_threshold_mean_supervised\": 0.35, \"unet_25d_status\": \"ok\", \"unet_25d_best_fbeta\": 0.0, \"forensic_report_generated\": true, \"probability_max_observed\": 0.1458509862422943, \"probability_mean_observed\": 0.09743015468120575, \"probability_std_observed\": 0.035574305802583694, \"learning_percent_real\": 100.0, \"reasoning_trace_events\": 4047, \"train_pair_count_discovered\": 786, \"train_pair_coverage_pct\": 4.071246819338422, \"calc_per_sec_global\": 10676.993625822597, \"elapsed_total_s\": 2608.674405559, \"ratio_selected_mean\": 0.205, \"signature\": \"9b0c60b60049d3f5101121d274593d44bab949edbc9a3e4e37e4ec13d64a598166f0374a9bcef5cb423cbe54d73b23dba3f32e32bbb83ef52596bd2e14b26ca2\", \"prev_merkle\": \"026729c8a30411a13d5410ccc9d7e96a7bb28dc8be52a0288085336dc3950adb6e853a1c968255f4f4eea6aeda8b18f111bb4dce97869f173ff7c6ec821fbbd7\", \"merkle\": \"57fcccb0f9a958054a582c660c19bfb6328fbe38a6975fee632e48d208feae84649d0eab302694c47847af3d58f81b68fdf7ca10fad22c630623110fee5c5505\"}",
+          "2627.7s 4067 {\"ts_ns\": 1771445290768407535, \"event\": \"EXEC_COMPLETE\", \"submission\": \"/kaggle/working/submission.zip\", \"signature\": \"54ed09d8304f6f6a2edb5dc392d372890001d326bc84cb39a6572c4791cfd6bd2a321381fa4861ff8896d6a80cd0217311512059eb8a5d5c7ae3cdfefa662aff\", \"prev_merkle\": \"57fcccb0f9a958054a582c660c19bfb6328fbe38a6975fee632e48d208feae84649d0eab302694c47847af3d58f81b68fdf7ca10fad22c630623110fee5c5505\", \"merkle\": \"83666dfc1416407c09307901367640e99de68e8a96b58dcb5517b4d5b434421c694e220ae79817e59d2fd38f116bb1b71425476c5ebe1e3f2be34e55ba1de0d6\"}",
+          "2627.8s 4068 READY: /kaggle/working/submission.zip",
+          "2632.8s 4069 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "2632.8s 4070 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "2633.0s 4071 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "2633.0s 4072 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "2633.7s 4073 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2633.7s 4074 warn(",
+          "2633.7s 4075 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "2635.2s 4076 [NbConvertApp] Writing 4441539 bytes to __notebook__.ipynb",
+          "2637.8s 4077 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "2637.8s 4078 warn(",
+          "2637.9s 4079 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "2639.2s 4080 [NbConvertApp] Writing 5818138 bytes to __results__.html"
+        ]
+      }
+    ]
+  },
+  "notebook-version-NX47-V61.2": {
+    "exists": true,
+    "files": [
+      {
+        "file": "notebook-version-NX47-V61.2/BRzSoZeY.txt",
+        "size": 6984,
+        "lines": 87,
+        "errors": 0,
+        "warnings": 4,
+        "has_score_0387": false,
+        "has_offline": false,
+        "tail": [
+          "27.9s 73 [1771420669286661814][SEQ:000007] SUBMISSION_READY {\"zip\": \"/kaggle/working/submission.zip\"}",
+          "27.9s 74 [1771420669286722745][SEQ:000008] EXEC_COMPLETE {}",
+          "27.9s 75 READY: /kaggle/working/submission.zip",
+          "30.3s 76 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "30.3s 77 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "30.4s 78 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "30.4s 79 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "31.2s 80 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "31.2s 81 warn(",
+          "31.2s 82 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "31.6s 83 [NbConvertApp] Writing 18257 bytes to __notebook__.ipynb",
+          "34.0s 84 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "34.0s 85 warn(",
+          "34.0s 86 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "34.8s 87 [NbConvertApp] Writing 323994 bytes to __results__.html"
+        ]
+      },
+      {
+        "file": "notebook-version-NX47-V61.2/PLAN_V61_2_FEUILLE_DE_ROUTE_COMPLETE.md",
+        "size": 2578
+      },
+      {
+        "file": "notebook-version-NX47-V61.2/nx47-vesu-kernel-new-v61-2.ipynb",
+        "size": 18268
+      },
+      {
+        "file": "notebook-version-NX47-V61.2/nx47-vesu-kernel-new-v61-2.log",
+        "size": 6984,
+        "lines": 87,
+        "errors": 0,
+        "warnings": 4,
+        "has_score_0387": false,
+        "has_offline": false,
+        "tail": [
+          "27.9s 73 [1771420669286661814][SEQ:000007] SUBMISSION_READY {\"zip\": \"/kaggle/working/submission.zip\"}",
+          "27.9s 74 [1771420669286722745][SEQ:000008] EXEC_COMPLETE {}",
+          "27.9s 75 READY: /kaggle/working/submission.zip",
+          "30.3s 76 /usr/local/lib/python3.12/dist-packages/mistune.py:435: SyntaxWarning: invalid escape sequence '\\|'",
+          "30.3s 77 cells[i][c] = re.sub('\\\\\\\\\\|', '|', cell)",
+          "30.4s 78 /usr/local/lib/python3.12/dist-packages/nbconvert/filters/filter_links.py:36: SyntaxWarning: invalid escape sequence '\\_'",
+          "30.4s 79 text = re.sub(r'_', '\\_', text) # Escape underscores in display text",
+          "31.2s 80 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"remove_papermill_header.RemovePapermillHeader\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "31.2s 81 warn(",
+          "31.2s 82 [NbConvertApp] Converting notebook __notebook__.ipynb to notebook",
+          "31.6s 83 [NbConvertApp] Writing 18257 bytes to __notebook__.ipynb",
+          "34.0s 84 /usr/local/lib/python3.12/dist-packages/traitlets/traitlets.py:2915: FutureWarning: --Exporter.preprocessors=[\"nbconvert.preprocessors.ExtractOutputPreprocessor\"] for containers is deprecated in traitlets 5.0. You can pass `--Exporter.preprocessors item` ... multiple times to add items to a list.",
+          "34.0s 85 warn(",
+          "34.0s 86 [NbConvertApp] Converting notebook __notebook__.ipynb to html",
+          "34.8s 87 [NbConvertApp] Writing 323994 bytes to __results__.html"
+        ]
+      },
+      {
+        "file": "notebook-version-NX47-V61.2/nx47-vesuvius-challenge-surface-detection-v61.2.py",
+        "size": 8949
+      },
+      {
+        "file": "notebook-version-NX47-V61.2/results.zip",
+        "size": 4703302,
+        "zip": {
+          "path": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.2/results.zip",
+          "entries": [
+            {
+              "name": "final_logs/forensic_audit_1771420660.log",
+              "size": 60,
+              "compress_size": 62
+            },
+            {
+              "name": "nx47_vesuvius/submission.zip",
+              "size": 2300099,
+              "compress_size": 2350642
+            },
+            {
+              "name": "submission.zip",
+              "size": 2300099,
+              "compress_size": 2350642
+            },
+            {
+              "name": "v28_forensic_logs/forensic_v28_cdffa7284d7d4c78.log",
+              "size": 1714,
+              "compress_size": 1076
+            },
+            {
+              "name": "v28_forensic_logs/wal_v28_cdffa7284d7d4c78.bin",
+              "size": 56,
+              "compress_size": 40
+            }
+          ],
+          "nested": [
+            {
+              "name": "nx47_vesuvius/submission.zip",
+              "entries": [
+                {
+                  "name": "1407735.tif",
+                  "size": 2299979,
+                  "compress_size": 2299979
+                }
+              ]
+            },
+            {
+              "name": "submission.zip",
+              "entries": [
+                {
+                  "name": "1407735.tif",
+                  "size": 2299979,
+                  "compress_size": 2299979
+                }
+              ]
+            }
+          ],
+          "tiffs": [
+            {
+              "container": "nx47_vesuvius/submission.zip",
               "name": "1407735.tif",
               "shape": [
                 320,
@@ -363,21 +396,122 @@
               "dtype": "uint8",
               "min": 0,
               "max": 1,
-              "nonzero": 767360
+              "mean": 0.12256454467773438
+            },
+            {
+              "container": "submission.zip",
+              "name": "1407735.tif",
+              "shape": [
+                320,
+                320,
+                320
+              ],
+              "dtype": "uint8",
+              "min": 0,
+              "max": 1,
+              "mean": 0.12256454467773438
             }
-          }
-        }
-      },
-      "log_summary": {
-        "AdmY-IOr.txt": {
-          "traceback": 0,
-          "runtime_error": 0,
-          "exec_complete": 0,
-          "ready_submission": 1,
-          "rules_validation_failed": 0,
-          "competition_validation_ok": 0
+          ]
         }
       }
+    ]
+  },
+  "src_vesuvius/v7.4": {
+    "exists": true,
+    "files": [
+      {
+        "file": "src_vesuvius/v7.4/PLAN_V7_4_FEUILLE_DE_ROUTE_COMPLETE.md",
+        "size": 2329
+      },
+      {
+        "file": "src_vesuvius/v7.4/nx46-vesuvius-core-kaggle-ready-v7.4.py",
+        "size": 38945
+      }
+    ]
+  },
+  "src_vesuvius/v7.5": {
+    "exists": true,
+    "files": [
+      {
+        "file": "src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md",
+        "size": 821
+      },
+      {
+        "file": "src_vesuvius/v7.5/nx46-vesuvius-core-kaggle-ready-v7.5.py",
+        "size": 40127
+      },
+      {
+        "file": "src_vesuvius/v7.5/run_campaigns_v61_3_v7_5.py",
+        "size": 1739
+      }
+    ]
+  },
+  "code_audit": {
+    "notebook-version-NX47-V140/nx47-vesu-kernel-new-v140.py": {
+      "todo": 0,
+      "fixme": 0,
+      "pass_stmt": 4,
+      "placeholder": 0,
+      "stub": 0,
+      "hardcoded_path_kaggle": 9
+    },
+    "notebook-version-NX47-V144/nx47-vesu-kernel-new-v144.py": {
+      "todo": 0,
+      "fixme": 0,
+      "pass_stmt": 4,
+      "placeholder": 0,
+      "stub": 0,
+      "hardcoded_path_kaggle": 9
     }
-  }
+  },
+  "roadmaps": [
+    {
+      "file": "FEUILLE_DE_ROUTE_V5_NX46_VESUVIUS.md",
+      "lines": 52,
+      "checkbox_todo": 0,
+      "checkbox_done": 0,
+      "mentions_go": 4,
+      "mentions_no_go": 2
+    },
+    {
+      "file": "PLAN_CAHIER_DE_CHANCE_FEUILLE_DE_ROUTE_AZ.md",
+      "lines": 418,
+      "checkbox_todo": 0,
+      "checkbox_done": 0,
+      "mentions_go": 0,
+      "mentions_no_go": 0
+    },
+    {
+      "file": "notebook-version-NX47-V61.2/PLAN_V61_2_FEUILLE_DE_ROUTE_COMPLETE.md",
+      "lines": 57,
+      "checkbox_todo": 0,
+      "checkbox_done": 0,
+      "mentions_go": 0,
+      "mentions_no_go": 0
+    },
+    {
+      "file": "notebook-version-NX47-V61.3/output_logs_vesuvius/v4-outlput-logs--nx46-vesuvius-core-kaggle-ready/PLAN_FEUILLE_DE_ROUTE_V4_REPONSES_EXPERTES.md",
+      "lines": 569,
+      "checkbox_todo": 36,
+      "checkbox_done": 0,
+      "mentions_go": 0,
+      "mentions_no_go": 0
+    },
+    {
+      "file": "src_vesuvius/v7.4/PLAN_V7_4_FEUILLE_DE_ROUTE_COMPLETE.md",
+      "lines": 57,
+      "checkbox_todo": 0,
+      "checkbox_done": 0,
+      "mentions_go": 0,
+      "mentions_no_go": 0
+    },
+    {
+      "file": "src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md",
+      "lines": 20,
+      "checkbox_todo": 0,
+      "checkbox_done": 0,
+      "mentions_go": 0,
+      "mentions_no_go": 0
+    }
+  ]
 }

--- a/RAPPORT-VESUVIUS/notebook-version-NX47-V144.1/PLAN_V144_1_INTEGRATION_LUM_VORAX_MULTI_SEUIL.md
+++ b/RAPPORT-VESUVIUS/notebook-version-NX47-V144.1/PLAN_V144_1_INTEGRATION_LUM_VORAX_MULTI_SEUIL.md
@@ -1,0 +1,29 @@
+# PLAN V144.1 — Correction score + pipeline `.lum` + multi-seuil progressif
+
+## Objectif
+Corriger la baisse score V144.1 par calibration multi-seuil, normalisation de sortie et traçabilité renforcée.
+
+## Priorités P0
+1. Corriger version stamping interne (artefacts `v139_*` -> `v144.1`).
+2. Normaliser sortie binaire configurable (`0/1` par défaut, `0/255` option explicite).
+3. Ajouter calibration multi-seuil progressive + accumulation 3D.
+
+## Intégration LUM/VORAX
+- Ajouter conversion interne `.lum` (Python first) pour éviter écarts de conversion entre formats.
+- Ajouter fallback C/C++ optionnel (ctypes + `.so`) sans bloquer exécution Kaggle.
+
+## Contrôles obligatoires
+- `density_diagnostics.json`: densité globale + par tranche z.
+- `train_pair_used_count` et `train_pair_coverage_pct` explicites.
+- `precision/recall` estimés par tranche et global.
+
+## Plan d’expérimentation
+- Run A: seuil bas + accumulation stricte.
+- Run B: seuil médian + accumulation.
+- Run C: seuil haut + accumulation.
+- Run D: profil mixte adaptatif par tranche z.
+
+## Go / No-Go
+- GO si score > 0.269 et format submission conforme.
+- NO-GO sinon et rollback sur meilleure config scorée.
+

--- a/RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/PLAN_V61_3_INTEGRATION_LUM_VORAX_MULTI_SEUIL.md
+++ b/RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/PLAN_V61_3_INTEGRATION_LUM_VORAX_MULTI_SEUIL.md
@@ -1,0 +1,27 @@
+# PLAN V61.3 — Intégration LUM/VORAX + calibration multi-seuil 3D
+
+## Objectif
+Transformer V61.3 en pipeline calibrable par couches de seuil et prêt pour flux canonique `.lum`.
+
+## Architecture cible
+1. Ingestion TIFF/ZIP Kaggle.
+2. Conversion interne `.lum` (Python) + checksum.
+3. Segmentation multi-seuil (`t_low`, `t_mid`, `t_high`).
+4. Accumulation 3D contrôlée (`density_target_range`).
+5. Export TIFF submission Kaggle 3D.
+
+## Étapes
+- E1: Ajouter `density_diagnostics.json` (`global`, `z-wise`, percentiles).
+- E2: Ajouter module `lum_adapter.py` (read/write `.lum` minimal).
+- E3: Implémenter fusion multi-seuil avec nettoyage progressif.
+- E4: Bench A/B (seuil unique vs multi-seuil) avec mêmes seeds.
+
+## KPI
+- Respect format Kaggle 3D.
+- Gain score vs V61.3 actuel.
+- Densité stabilisée dans plage validée.
+
+## Risques
+- Sur-segmentation si accumulation non contrainte.
+- Coût CPU en hausse (acceptable à ce stade).
+

--- a/RAPPORT-VESUVIUS/plan_roadmap_audit_inventory.json
+++ b/RAPPORT-VESUVIUS/plan_roadmap_audit_inventory.json
@@ -1,50 +1,120 @@
 {
-  "count": 5,
+  "count": 6,
   "plans": [
     {
       "path": "RAPPORT-VESUVIUS/FEUILLE_DE_ROUTE_V5_NX46_VESUVIUS.md",
       "size": 1898,
-      "mtime": 1771447462.0896962,
-      "mentions_progress": true,
+      "line_count": 52,
+      "mentions_progress": false,
       "mentions_pending": true,
-      "mentions_done": true,
-      "first_lines": "# FEUILLE DE ROUTE V5 — NX46 Vesuvius (mise à jour opérationnelle)\n\nDate: 2026-02-18\n\n## 1) Objectif\nStabiliser la chaîne NX46 pour garantir:\n1. conformité soumission Kaggle (format + contenu),\n2. robustesse offline,"
+      "mentions_done": false
     },
     {
       "path": "RAPPORT-VESUVIUS/PLAN_CAHIER_DE_CHANCE_FEUILLE_DE_ROUTE_AZ.md",
       "size": 21477,
-      "mtime": 1771430147.9920242,
-      "mentions_progress": true,
-      "mentions_pending": true,
-      "mentions_done": false,
-      "first_lines": "# PLAN COMPLET A→Z — Reprise complète avec récupération GitHub distante réussie\n\n## 1) Ce que j’ai refait (recommencé proprement)\n\nVous avez raison: il fallait **recommencer en allant chercher les données sur GitHub distant**.\n\n### 1.1 Récupération distante effectuée\n- Clone distant exécuté avec succès depuis GitHub: `https://github.com/lumc01/Lumvorax.git`."
+      "line_count": 418,
+      "mentions_progress": false,
+      "mentions_pending": false,
+      "mentions_done": true
     },
     {
       "path": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.2/PLAN_V61_2_FEUILLE_DE_ROUTE_COMPLETE.md",
       "size": 2578,
-      "mtime": 1771430148.776009,
+      "line_count": 57,
       "mentions_progress": true,
       "mentions_pending": true,
-      "mentions_done": true,
-      "first_lines": "# NX47 V61.2 — Plan de réalisation complet (A→Z)\n\n## 1) Objectif de version\nMonter NX47 de la base confirmée **0.387** vers une version plus stable/plus précise sans casser la conformité Kaggle.\n\n## 2) Contraintes non négociables\n- TIFF multipage 3D `(Z,H,W)`.\n- `uint8` binaire strict `{0,1}` aligné format concurrent."
+      "mentions_done": false
     },
     {
       "path": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.3/output_logs_vesuvius/v4-outlput-logs--nx46-vesuvius-core-kaggle-ready/PLAN_FEUILLE_DE_ROUTE_V4_REPONSES_EXPERTES.md",
       "size": 20155,
-      "mtime": 1771447300.8848543,
-      "mentions_progress": true,
-      "mentions_pending": true,
-      "mentions_done": true,
-      "first_lines": "# PLAN + FEUILLE DE ROUTE V4 — Réponses expertes à tes questions\n\n## 0) Domaines d’expertise mobilisés en temps réel\n\nPour répondre correctement à tes questions, les domaines nécessaires identifiés sont:\n1. **Computer Vision 3D (TIFF volumique Vesuvius)**\n2. **ML Engineering (pipeline train/infer, calibration seuil)**\n3. **Performance Engineering (CPU/IO, coût runtime)**"
+      "line_count": 569,
+      "mentions_progress": false,
+      "mentions_pending": false,
+      "mentions_done": true
     },
     {
       "path": "RAPPORT-VESUVIUS/src_vesuvius/v7.4/PLAN_V7_4_FEUILLE_DE_ROUTE_COMPLETE.md",
       "size": 2329,
-      "mtime": 1771430148.8920069,
+      "line_count": 57,
       "mentions_progress": true,
       "mentions_pending": true,
-      "mentions_done": true,
-      "first_lines": "# NX46 V7.4 — Plan de réalisation complet (A→Z)\n\n## 1) Objectif de version\nAméliorer la base v7.3 (**0.303**) sans perdre la robustesse format Kaggle déjà acquise.\n\n## 2) Point de départ validé\n- v7.3 est robuste sur le packaging/format (3D, contrôles shape/valeurs).\n- Risque identifié: pipeline potentiellement trop conservateur (sous-détection)."
+      "mentions_done": false
+    },
+    {
+      "path": "RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md",
+      "size": 821,
+      "line_count": 20,
+      "mentions_progress": false,
+      "mentions_pending": false,
+      "mentions_done": false
     }
+  ],
+  "directory_coverage": [
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V102",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V107",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V140",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V140.1",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V144",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V144.1",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.1",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.2",
+      "has_plan_or_roadmap": true,
+      "md_count": 1
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-V61.3",
+      "has_plan_or_roadmap": true,
+      "md_count": 4
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/notebook-version-NX47-score-0.387-V61",
+      "has_plan_or_roadmap": false,
+      "md_count": 0
+    },
+    {
+      "dir": "RAPPORT-VESUVIUS/src_vesuvius",
+      "has_plan_or_roadmap": true,
+      "md_count": 2
+    }
+  ],
+  "missing_plan_dirs": [
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V102",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V107",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V140",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V140.1",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V144",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V144.1",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-V61.1",
+    "RAPPORT-VESUVIUS/notebook-version-NX47-score-0.387-V61"
   ]
 }

--- a/RAPPORT-VESUVIUS/src_vesuvius/lum_vorax_kaggle_bootstrap.py
+++ b/RAPPORT-VESUVIUS/src_vesuvius/lum_vorax_kaggle_bootstrap.py
@@ -1,0 +1,83 @@
+"""Reusable Kaggle bootstrap for NX/LUM-VORAX dependencies.
+
+This module is designed to be vendored into notebooks (copy/paste or import) so that
+all active versions can install wheels from both existing NX47 dependency datasets and
+new LUM-VORAX wheel datasets.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+def _is_available(pkg: str) -> bool:
+    return importlib.util.find_spec(pkg) is not None
+
+
+def install_offline(pkg: str, extra_roots: Iterable[str] = ()) -> None:
+    if _is_available(pkg):
+        return
+
+    roots = [
+        Path("/kaggle/input/datasets/ndarray2000/nx47-dependencies"),
+        Path("/kaggle/input/nx47-dependencies"),
+        Path("/kaggle/input/lum-vorax-dependencies"),
+        Path("/kaggle/input/lumvorax-dependencies"),
+    ] + [Path(x) for x in extra_roots]
+
+    for root in roots:
+        if root.exists():
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--no-index", f"--find-links={root}", pkg]
+            )
+            if _is_available(pkg):
+                return
+
+    raise RuntimeError(
+        f"Offline dependency not found for {pkg}. Checked roots: {', '.join(str(r) for r in roots)}"
+    )
+
+
+def bootstrap_nx47_lum_vorax(extra_roots: Iterable[str] = ()) -> None:
+    for pkg in ("numpy", "pandas", "pyarrow", "tifffile", "imagecodecs"):
+        install_offline(pkg, extra_roots=extra_roots)
+
+
+def compile_optional_lum_vorax_so(output_path: str = "/kaggle/working/liblumvorax.so") -> str:
+    """Best-effort local compile for optional ctypes bridge.
+
+    No-op if gcc is unavailable.
+    """
+
+    src_candidates = [
+        "/kaggle/working/src/vorax/vorax_operations.c",
+        "/kaggle/working/src/lum/lum_core.c",
+        "/kaggle/working/src/logger/lum_logger.c",
+    ]
+
+    available = [p for p in src_candidates if os.path.exists(p)]
+    if len(available) < 2:
+        return ""
+
+    cmd = [
+        "gcc",
+        "-shared",
+        "-fPIC",
+        "-O3",
+        "-o",
+        output_path,
+        *available,
+    ]
+
+    try:
+        subprocess.check_call(cmd)
+    except Exception:
+        return ""
+
+    return output_path if os.path.exists(output_path) else ""
+

--- a/RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md
+++ b/RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md
@@ -58,3 +58,23 @@ Exécuter 10 variantes de calibrage seuil/poids 3D pour améliorer le rappel san
 ### Étape 3 — Go/No-Go
 - **GO** si score > 0.303 ET conformité zip/tiff inchangée.
 - **NO-GO** sinon; conserver la meilleure config scorée.
+
+
+---
+
+## Extension demandée — Intégration LUM/VORAX + multi-seuil progressif
+
+### Stratégie technique
+1. Exécuter une cascade de seuils (`t_low -> t_mid -> t_high`) au lieu d’un seuil unique.
+2. Nettoyer à chaque étage (morphologie/consensus z-wise) puis accumuler les couches 3D.
+3. Contraindre la sortie finale dans une plage densité cible pilotée par benchmark.
+
+### Intégration `.lum` (Kaggle exécutable)
+- Étape 1 (immédiate): format `.lum` Python canonique pour tous calculs intermédiaires.
+- Étape 2 (optionnelle): appel C/C++ `lum/vorax` via `ctypes` si compilation `.so` disponible.
+- Fallback obligatoire Python pur si interop C indisponible.
+
+### Questions d’implémentation
+- Quel gain réel score/runtime du mode multi-seuil vs seuil unique ?
+- Quelle plage densité cible maximise score sur v7.5 sans casser la précision ?
+- Quel coût `tif -> lum -> tif` et quel ratio coût/bénéfice sur Kaggle ?

--- a/RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md
+++ b/RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md
@@ -18,3 +18,43 @@ Exécuter 10 variantes de calibrage seuil/poids 3D pour améliorer le rappel san
 ## Résultat d’exécution ici
 - 10/10 runs préflight local exécutés (retour 0).
 - Limitation: scoring Kaggle non exécutable ici (absence de runtime Kaggle + chemins `/kaggle/input/*`).
+
+---
+
+## Mise à jour score Kaggle (retour utilisateur)
+- Soumission réussie `nx46_vesuvius_core_kaggle_ready` (Version 14): **Public Score = 0.303**.
+- Référence NX47 V61.2: **0.387**.
+
+Écart observé: **-0.084** vs baseline 0.387.
+
+---
+
+## Analyse rapide de cause probable (avec artefacts offline)
+- Le `results.zip` v7.5 est conforme (TIFF 3D `uint8` binaire `0/1`).
+- Densité finale de soumission (`ink_ratio`) observée: **0.02341797** (≈2.34%), très faible.
+- Cette sous-densité est cohérente avec un risque de **rappel insuffisant** (under-segmentation).
+
+---
+
+## Questions critiques à traiter au prochain run
+1. Quel `threshold_quantile` permet de remonter la densité entre 0.06 et 0.12 sans exploser les faux positifs ?
+2. Le `score_blend_3d_weight=0.78` est-il trop conservateur pour les tranches faibles ?
+3. Quels z-slices concentrent la perte de rappel (analyse `ink_ratio_by_slice`) ?
+4. Quelle combinaison seuil + smoothing garde le format conforme et remonte le score LB > 0.303 ?
+
+---
+
+## Feuille de route corrective (itération courte)
+
+### Étape 1 — Diagnostic densité
+- Exporter et versionner `ink_ratio_global` + `ink_ratio_by_slice` + percentiles de probas.
+- Définir une plage cible de densité validée par rapport aux runs scorés.
+
+### Étape 2 — Mini A/B/C calibration
+- Run A: quantile plus permissif (+recall)
+- Run B: blend 3D réduit
+- Run C: combinaison A+B
+
+### Étape 3 — Go/No-Go
+- **GO** si score > 0.303 ET conformité zip/tiff inchangée.
+- **NO-GO** sinon; conserver la meilleure config scorée.

--- a/RAPPORT-VESUVIUS/src_vesuvius/v7.5/nx46-vesuvius-core-kaggle-ready-v7.5.py
+++ b/RAPPORT-VESUVIUS/src_vesuvius/v7.5/nx46-vesuvius-core-kaggle-ready-v7.5.py
@@ -42,6 +42,8 @@ if DRY_RUN_FLAG and __name__ == "__main__":
 def install_offline(package_name: str) -> None:
     exact_wheel_dir = Path("/kaggle/input/datasets/ndarray2000/nx47-dependencies")
     fallback_wheel_dir = Path("/kaggle/input/nx47-dependencies")
+    lum_wheel_dir = Path("/kaggle/input/lum-vorax-dependencies")
+    lum_wheel_dir_alt = Path("/kaggle/input/lumvorax-dependencies")
 
     exact_wheels = {
         "imagecodecs": exact_wheel_dir / "imagecodecs-2026.1.14-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
@@ -59,7 +61,7 @@ def install_offline(package_name: str) -> None:
         except subprocess.CalledProcessError:
             pass
 
-    for wheel_dir in (exact_wheel_dir, fallback_wheel_dir):
+    for wheel_dir in (exact_wheel_dir, fallback_wheel_dir, lum_wheel_dir, lum_wheel_dir_alt):
         if wheel_dir.exists():
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "install", "--no-index", f"--find-links={wheel_dir}", package_name]

--- a/nx47_vesu_kernel_v2.py
+++ b/nx47_vesu_kernel_v2.py
@@ -1,13 +1,16 @@
+import ctypes
 import glob
+import importlib
+import io
 import json
 import os
+import struct
 import time
+import zipfile
 from dataclasses import dataclass
 from hashlib import sha512
-from typing import Dict, List
-
-import numpy as np
-import pandas as pd
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
 
 
 class FatalPipelineError(RuntimeError):
@@ -20,8 +23,52 @@ class CompatibilityLayer:
     required_capabilities: List[str]
 
 
+@dataclass(frozen=True)
+class LUMVolume:
+    shape: Tuple[int, int, int]
+    dtype: str
+    payload_sha512: str
+
+
+class LumVoraxBridge:
+    """Optional bridge to native LUM/VORAX C/C++ libraries via ctypes.
+
+    Bridge is optional by design: pipeline remains fully functional in pure Python
+    when no native shared library is available in Kaggle runtime.
+    """
+
+    def __init__(self) -> None:
+        self.lib = None
+        self.loaded_path = None
+
+        candidates = [
+            os.environ.get("LUM_VORAX_LIB_PATH", ""),
+            "/kaggle/working/liblumvorax.so",
+            "/kaggle/working/libvorax.so",
+            "/kaggle/input/lum-vorax-dependencies/liblumvorax.so",
+            "/kaggle/input/lum-vorax-dependencies/libvorax.so",
+        ]
+        for candidate in candidates:
+            if candidate and os.path.exists(candidate):
+                self.lib = ctypes.CDLL(candidate)
+                self.loaded_path = candidate
+                break
+
+    @property
+    def enabled(self) -> bool:
+        return self.lib is not None
+
+
 class NX47_VESU_Production:
-    """NX-47 V132 strict pipeline with inherited compatibility checks NX-1→NX-47."""
+    """NX-47 VESU production pipeline (Kaggle-ready, fail-fast, forensic).
+
+    Key guarantees:
+    - No synthetic fragment fallback.
+    - Real TIFF input ingestion (2D or 3D, normalized to 3D).
+    - Progressive multi-threshold 3D accumulation with target density clamping.
+    - Optional `.lum` canonical intermediate serialization.
+    - Optional native LUM/VORAX bridge via ctypes (non-blocking fallback).
+    """
 
     ROADMAP_STEPS = [
         "bootstrap",
@@ -33,8 +80,10 @@ class NX47_VESU_Production:
         "finalize",
     ]
 
+    LUM_MAGIC = b"LUMV1\x00\x00\x00"
+
     def __init__(self, input_dir=None, output_dir=None):
-        self.version = "NX-47 VESU PROD V132-STRICT"
+        self.version = "NX-47 VESU PROD V133-REAL-PY"
         self.audit_log: List[Dict] = []
         self.start_time = time.time_ns()
         self.input_dir = input_dir or "/kaggle/input/vesuvius-challenge-surface-detection"
@@ -42,9 +91,13 @@ class NX47_VESU_Production:
         self.processed_pixels = 0
         self.ink_detected = 0
         self.fallback_disabled = True
-        self.roadmap_path = os.path.join(self.output_dir, "v132_roadmap_realtime.json")
-        self.execution_log_path = os.path.join(self.output_dir, "v132_execution_logs.json")
-        self.metadata_path = os.path.join(self.output_dir, "v132_execution_metadata.json")
+        self.roadmap_path = os.path.join(self.output_dir, "v133_roadmap_realtime.json")
+        self.execution_log_path = os.path.join(self.output_dir, "v133_execution_logs.json")
+        self.metadata_path = os.path.join(self.output_dir, "v133_execution_metadata.json")
+        self.submission_zip_path = os.path.join(self.output_dir, "submission.zip")
+        self.submission_parquet_path = os.path.join(self.output_dir, "submission.parquet")
+        self.lum_work_dir = os.path.join(self.output_dir, "lum_cache")
+        self.bridge = LumVoraxBridge()
 
         self.capability_registry = {
             "preprocess_invariants": self.spatial_harmonic_filtering_simd,
@@ -59,6 +112,7 @@ class NX47_VESU_Production:
             "strict_train_evidence_gate": self._strict_training_evidence_gate,
             "adaptive_thresholding": self.ink_resonance_detector_v47,
             "dynamic_neuron_telemetry": self._emit_neuron_telemetry,
+            "lum_encode_decode": self._roundtrip_lum,
         }
 
         self.compatibility_layers = [
@@ -70,12 +124,46 @@ class NX47_VESU_Production:
                 ["forensic_traceability", "merkle_ready_events", "realtime_roadmap", "dynamic_neuron_telemetry"],
             ),
             CompatibilityLayer(
-                "NX-47 v115..v132",
-                ["strict_train_evidence_gate", "adaptive_thresholding", "realtime_roadmap"],
+                "NX-47 v115..v133",
+                ["strict_train_evidence_gate", "adaptive_thresholding", "realtime_roadmap", "lum_encode_decode"],
             ),
         ]
 
-        print(f"[{self.version}] System Initialized. Strict Fail-Fast + Roadmap Realtime Active.")
+        print(f"[{self.version}] System Initialized. Real TIFF processing + `.lum` roundtrip + fail-fast active.")
+
+    @staticmethod
+    def _is_pkg_available(package_name: str) -> bool:
+        return importlib.util.find_spec(package_name) is not None
+
+    def install_offline(self, package_name: str) -> None:
+        import subprocess
+        import sys
+
+        if self._is_pkg_available(package_name):
+            return
+
+        wheel_roots = [
+            Path("/kaggle/input/datasets/ndarray2000/nx47-dependencies"),
+            Path("/kaggle/input/nx47-dependencies"),
+            Path("/kaggle/input/lum-vorax-dependencies"),
+            Path("/kaggle/input/lumvorax-dependencies"),
+        ]
+        for root in wheel_roots:
+            if root.exists():
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "--no-index", f"--find-links={root}", package_name]
+                )
+                if self._is_pkg_available(package_name):
+                    return
+
+        raise FatalPipelineError(
+            f"OFFLINE_DEPENDENCY_MISSING: {package_name} not found in known wheel directories."
+        )
+
+    def bootstrap_dependencies_fail_fast(self) -> None:
+        # pandas/pyarrow required for parquet output path.
+        for pkg in ("numpy", "pandas", "tifffile", "imagecodecs", "pyarrow"):
+            self.install_offline(pkg)
 
     def log_event(self, event_type, details, severity="INFO"):
         ts = time.time_ns()
@@ -108,7 +196,9 @@ class NX47_VESU_Production:
             "timestamp_ns": time.time_ns(),
             "current_step": current_step,
             "status": status,
-            "overall_progress_percent": round(((current_idx + (1 if status == "done" else 0)) / len(self.ROADMAP_STEPS)) * 100, 2),
+            "overall_progress_percent": round(
+                ((current_idx + (1 if status == "done" else 0)) / len(self.ROADMAP_STEPS)) * 100, 2
+            ),
             "milestones": milestones,
         }
         os.makedirs(self.output_dir, exist_ok=True)
@@ -116,9 +206,33 @@ class NX47_VESU_Production:
             json.dump(roadmap, f, indent=2)
 
     def _validate_input_structure(self):
-        test_dir = os.path.join(self.input_dir, "test")
-        if not os.path.isdir(test_dir):
-            raise FatalPipelineError(f"INPUT_STRUCTURE_INVALID: missing directory {test_dir}")
+        if not os.path.isdir(self.input_dir):
+            raise FatalPipelineError(f"INPUT_ROOT_INVALID: missing directory {self.input_dir}")
+
+    def _collect_test_fragments(self) -> List[str]:
+        candidates = []
+        patterns = [
+            f"{self.input_dir}/test/*.tif",
+            f"{self.input_dir}/test/*.tiff",
+            f"{self.input_dir}/test/**/**/*.tif",
+            f"{self.input_dir}/test/**/**/*.tiff",
+        ]
+        for pattern in patterns:
+            candidates.extend(glob.glob(pattern, recursive=True))
+
+        # competition fallback structure
+        if not candidates:
+            patterns = [
+                f"{self.input_dir}/**/test/*.tif",
+                f"{self.input_dir}/**/test/*.tiff",
+            ]
+            for pattern in patterns:
+                candidates.extend(glob.glob(pattern, recursive=True))
+
+        uniq = sorted({str(Path(p)) for p in candidates})
+        if not uniq:
+            raise FatalPipelineError(f"NO_TEST_FRAGMENTS_FOUND in {self.input_dir}")
+        return uniq
 
     def _validate_compatibility_chain(self):
         for layer in self.compatibility_layers:
@@ -128,25 +242,128 @@ class NX47_VESU_Production:
             self.log_event("COMPATIBILITY_LAYER_OK", {"layer": layer.name, "caps": layer.required_capabilities})
 
     def _strict_training_evidence_gate(self):
-        """Fail-fast gate: v132 is inference-oriented; if supervised mode is requested, evidence must exist."""
         expected = {
             "supervised_train": False,
             "val_f1_mean_supervised": None,
             "val_iou_mean_supervised": None,
+            "native_bridge_enabled": self.bridge.enabled,
+            "native_bridge_path": self.bridge.loaded_path,
         }
         self.log_event("STRICT_TRAINING_GATE", expected)
 
-    def spatial_harmonic_filtering_simd(self, slice_data):
-        fft_data = np.fft.fft2(slice_data)
-        mask = np.ones_like(slice_data)
-        rows, cols = slice_data.shape
-        mask[rows // 4 : 3 * rows // 4, cols // 4 : 3 * cols // 4] = 0.5
-        filtered = np.abs(np.fft.ifft2(fft_data * mask))
-        return filtered
+    @staticmethod
+    def _normalize_volume_shape(volume: "np.ndarray") -> "np.ndarray":
+        import numpy as np
+
+        arr = np.asarray(volume)
+        if arr.ndim == 2:
+            return arr[np.newaxis, :, :]
+        if arr.ndim == 3:
+            return arr
+        raise FatalPipelineError(f"UNSUPPORTED_VOLUME_DIM: expected 2D/3D, got {arr.ndim}D")
+
+    def _read_tiff_volume(self, path: str) -> "np.ndarray":
+        import tifffile
+
+        arr = tifffile.imread(path)
+        arr = self._normalize_volume_shape(arr)
+        if arr.shape[1] <= 0 or arr.shape[2] <= 0:
+            raise FatalPipelineError(f"INVALID_TIFF_SHAPE: {path} -> {arr.shape}")
+        return arr.astype("float32", copy=False)
+
+    def _lum_encode(self, volume: "np.ndarray") -> bytes:
+        import numpy as np
+
+        arr = self._normalize_volume_shape(volume)
+        payload = np.ascontiguousarray(arr.astype(np.float32)).tobytes()
+        digest = sha512(payload).digest()
+        z, h, w = arr.shape
+        header = struct.pack("<8sIII16s", self.LUM_MAGIC, z, h, w, digest[:16])
+        return header + payload
+
+    def _lum_decode(self, blob: bytes) -> "np.ndarray":
+        import numpy as np
+
+        header_size = struct.calcsize("<8sIII16s")
+        if len(blob) < header_size:
+            raise FatalPipelineError("LUM_DECODE_ERROR: blob too small")
+        magic, z, h, w, digest16 = struct.unpack("<8sIII16s", blob[:header_size])
+        if magic != self.LUM_MAGIC:
+            raise FatalPipelineError("LUM_DECODE_ERROR: bad magic")
+        payload = blob[header_size:]
+        expected_bytes = int(z) * int(h) * int(w) * 4
+        if len(payload) != expected_bytes:
+            raise FatalPipelineError("LUM_DECODE_ERROR: payload size mismatch")
+        if sha512(payload).digest()[:16] != digest16:
+            raise FatalPipelineError("LUM_DECODE_ERROR: checksum mismatch")
+        arr = np.frombuffer(payload, dtype=np.float32).reshape((z, h, w))
+        return arr
+
+    def _roundtrip_lum(self, volume: "np.ndarray") -> LUMVolume:
+        blob = self._lum_encode(volume)
+        decoded = self._lum_decode(blob)
+        payload_sha = sha512(decoded.tobytes()).hexdigest()
+        return LUMVolume(shape=tuple(decoded.shape), dtype=str(decoded.dtype), payload_sha512=payload_sha)
+
+    def spatial_harmonic_filtering_simd(self, volume):
+        import numpy as np
+
+        vol = self._normalize_volume_shape(volume)
+        filtered_slices = []
+        for slice_data in vol:
+            fft_data = np.fft.fft2(slice_data)
+            mask = np.ones_like(slice_data, dtype=np.float32)
+            rows, cols = slice_data.shape
+            mask[rows // 4 : 3 * rows // 4, cols // 4 : 3 * cols // 4] = 0.5
+            filtered_slices.append(np.abs(np.fft.ifft2(fft_data * mask)))
+        return np.stack(filtered_slices, axis=0)
+
+    @staticmethod
+    def _clamp_density(mask_3d: "np.ndarray", density_target: float) -> "np.ndarray":
+        import numpy as np
+
+        total = mask_3d.size
+        if total == 0:
+            return mask_3d
+        target_ones = int(total * density_target)
+        if target_ones <= 0:
+            return np.zeros_like(mask_3d, dtype=np.uint8)
+        if target_ones >= total:
+            return np.ones_like(mask_3d, dtype=np.uint8)
+
+        flat = mask_3d.reshape(-1).astype(np.float32)
+        if np.max(flat) <= 1.0 and np.min(flat) >= 0.0:
+            scores = flat
+        else:
+            mn = float(np.min(flat))
+            mx = float(np.max(flat))
+            scores = (flat - mn) / (mx - mn + 1e-8)
+
+        idx = np.argpartition(scores, -target_ones)[-target_ones:]
+        out = np.zeros_like(scores, dtype=np.uint8)
+        out[idx] = 1
+        return out.reshape(mask_3d.shape)
 
     def ink_resonance_detector_v47(self, filtered_data):
-        threshold = np.mean(filtered_data) + 2 * np.std(filtered_data)
-        return (filtered_data > threshold).astype(np.uint8)
+        import numpy as np
+
+        vol = self._normalize_volume_shape(filtered_data)
+        mean = float(np.mean(vol))
+        std = float(np.std(vol))
+        thresholds = [mean + 0.8 * std, mean + 1.2 * std, mean + 1.6 * std]
+
+        layer_low = (vol > thresholds[0]).astype(np.uint8)
+        layer_mid = (vol > thresholds[1]).astype(np.uint8)
+        layer_high = (vol > thresholds[2]).astype(np.uint8)
+
+        # progressive accumulation with strictness weighting
+        accum = (0.55 * layer_low + 0.30 * layer_mid + 0.15 * layer_high).astype(np.float32)
+        binary = (accum >= 0.5).astype(np.uint8)
+
+        # clamp to target density range to avoid extreme under/over segmentation
+        density_now = float(np.mean(binary))
+        target_density = min(max(density_now, 0.05), 0.12)
+        return self._clamp_density(accum, target_density)
 
     def _extract_fragment_signature(self, fragment_id):
         return sha512(f"{fragment_id}|NX47".encode()).hexdigest()[:24]
@@ -155,19 +372,29 @@ class NX47_VESU_Production:
         encoded = json.dumps(payload, sort_keys=True, default=str).encode()
         return sha512(encoded).hexdigest()
 
-    def _build_result_entry(self, frag_id, score):
+    def _build_result_entry(self, frag_id, score, density, shape):
         return {
             "id": frag_id,
             "target": float(score),
+            "density": float(density),
+            "shape_z": int(shape[0]),
+            "shape_h": int(shape[1]),
+            "shape_w": int(shape[2]),
             "feature_signature": self._extract_fragment_signature(frag_id),
         }
 
     def _emit_neuron_telemetry(self, filtered_data):
-        active = int(np.count_nonzero(filtered_data > np.mean(filtered_data)))
+        import numpy as np
+
+        vol = self._normalize_volume_shape(filtered_data)
+        total = int(vol.size)
+        active = int(np.count_nonzero(vol > np.mean(vol)))
+        mid = int(np.count_nonzero(vol > (np.mean(vol) + 0.5 * np.std(vol))))
+        end = int(np.count_nonzero(vol > (np.mean(vol) + 1.0 * np.std(vol))))
         return {
-            "active_neurons_start_total": 0,
-            "active_neurons_mid_total": min(active, 6),
-            "active_neurons_end_total": min(active, 6),
+            "active_neurons_start_total": total,
+            "active_neurons_mid_total": mid,
+            "active_neurons_end_total": end,
             "mutation_events": 0,
             "pruning_events": 1,
         }
@@ -183,6 +410,17 @@ class NX47_VESU_Production:
             current = [sha512(f"{current[i]}{current[i + 1]}".encode()).hexdigest() for i in range(0, len(current), 2)]
         return current[0]
 
+    def _write_submission_zip(self, masks: Dict[str, "np.ndarray"]) -> None:
+        import tifffile
+
+        os.makedirs(self.output_dir, exist_ok=True)
+        with zipfile.ZipFile(self.submission_zip_path, "w", compression=zipfile.ZIP_STORED) as zf:
+            for frag_id, mask in masks.items():
+                arr = self._normalize_volume_shape(mask).astype("uint8")
+                tif_buf = io.BytesIO()
+                tifffile.imwrite(tif_buf, arr, compression="lzw")
+                zf.writestr(f"{frag_id}.tif", tif_buf.getvalue())
+
     def _export_forensic(self, stats):
         os.makedirs(self.output_dir, exist_ok=True)
         with open(self.execution_log_path, "w", encoding="utf-8") as f:
@@ -194,13 +432,21 @@ class NX47_VESU_Production:
             "integrity_digest": self._integrity_digest(stats),
             "merkle_root": self._audit_merkle_root(),
             "fallback_disabled": self.fallback_disabled,
+            "native_bridge_enabled": self.bridge.enabled,
+            "native_bridge_path": self.bridge.loaded_path,
+            "submission_zip": self.submission_zip_path,
+            "submission_parquet": self.submission_parquet_path,
         }
         with open(self.metadata_path, "w", encoding="utf-8") as f:
             json.dump(metadata, f, indent=2)
 
     def process_fragments(self):
+        import pandas as pd
+
         self._update_roadmap("bootstrap", "in_progress")
         self.log_event("PIPELINE_START", "Beginning fragment processing")
+        self.bootstrap_dependencies_fail_fast()
+        os.makedirs(self.lum_work_dir, exist_ok=True)
 
         self._strict_training_evidence_gate()
         self._update_roadmap("bootstrap", "done")
@@ -211,9 +457,8 @@ class NX47_VESU_Production:
 
         self._update_roadmap("data_validation", "in_progress")
         self._validate_input_structure()
-        test_fragments = glob.glob(f"{self.input_dir}/test/*")
-        if not test_fragments:
-            raise FatalPipelineError(f"NO_TEST_FRAGMENTS_FOUND in {self.input_dir}")
+        test_fragments = self._collect_test_fragments()
+        self.log_event("TEST_FRAGMENT_DISCOVERY", {"count": len(test_fragments)})
         self._update_roadmap("data_validation", "done")
 
         self._update_roadmap("feature_extraction", "in_progress")
@@ -225,26 +470,39 @@ class NX47_VESU_Production:
             "mutation_events": 0,
             "pruning_events": 0,
         }
+        masks_for_zip: Dict[str, "np.ndarray"] = {}
 
         for frag in test_fragments:
-            frag_id = os.path.basename(frag)
-            self.log_event("FRAGMENT_PROCESSING", f"Processing: {frag_id}")
-            synthetic = np.random.default_rng(seed=len(frag_id)).random((64, 64))
-            filtered = self.spatial_harmonic_filtering_simd(synthetic)
+            frag_id = os.path.splitext(os.path.basename(frag))[0]
+            self.log_event("FRAGMENT_PROCESSING", {"fragment": frag_id, "path": frag})
+
+            volume = self._read_tiff_volume(frag)
+            lum_info = self._roundtrip_lum(volume)
+            self.log_event("LUM_ROUNDTRIP_OK", {"fragment": frag_id, "shape": lum_info.shape, "dtype": lum_info.dtype})
+
+            filtered = self.spatial_harmonic_filtering_simd(volume)
             pred = self.ink_resonance_detector_v47(filtered)
-            score = float(np.mean(pred))
-            results.append(self._build_result_entry(frag_id, score))
-            self.processed_pixels += filtered.size
-            self.ink_detected += int(np.sum(pred))
+
+            score = float(pred.mean())
+            density = float(pred.mean())
+            results.append(self._build_result_entry(frag_id, score, density, pred.shape))
+
+            masks_for_zip[frag_id] = pred
+            self.processed_pixels += int(filtered.size)
+            self.ink_detected += int(pred.sum())
             t = self._emit_neuron_telemetry(filtered)
-            telemetry.update(t)
+            for k in telemetry:
+                telemetry[k] += int(t.get(k, 0))
 
         self._update_roadmap("feature_extraction", "done")
 
         self._update_roadmap("inference", "in_progress")
         submission_df = pd.DataFrame(results)
-        submission_df[["id", "target"]].to_parquet(f"{self.output_dir}/submission.parquet")
-        self.log_event("SUBMISSION_GENERATED", f"Shape: {submission_df.shape}")
+        if submission_df.empty:
+            raise FatalPipelineError("NO_RESULTS_GENERATED")
+        submission_df[["id", "target"]].to_parquet(self.submission_parquet_path)
+        self._write_submission_zip(masks_for_zip)
+        self.log_event("SUBMISSION_GENERATED", {"shape": submission_df.shape, "zip": self.submission_zip_path})
         self._update_roadmap("inference", "done")
 
         self._update_roadmap("forensic_export", "in_progress")
@@ -252,8 +510,10 @@ class NX47_VESU_Production:
             "files_processed": len(results),
             "pixels_processed": self.processed_pixels,
             "ink_detected": self.ink_detected,
+            "mean_density": float(submission_df["density"].mean()),
             **telemetry,
             "files_autonomous_fallback": 0,
+            "lum_bridge_enabled": self.bridge.enabled,
         }
         self._export_forensic(stats)
         self._update_roadmap("forensic_export", "done")


### PR DESCRIPTION
### Motivation
- Re-analyse recent public scores (V144.1 = 0.269, V7.5 = 0.303 vs baseline V61.2 = 0.387) to surface probable root causes of regression.
- Provide concrete, score-aware diagnostics and an actionable run plan to recover recall while preserving submission conformity.
- Standardize forensic outputs so future runs include per-run density/coverage metrics for fast triage.

### Description
- Added a new forensic analysis report `RAPPORT-VESUVIUS/RAPPORT_MAJ_SCORES_V75_V1441_ANALYSE_DENSITE_20260219.md` containing offline ZIP/TIFF inspection, computed output densities, expert diagnostic, prioritized P0/P1/P2 remediation and critical questions to answer next.
- Added a more comprehensive audit (`RAPPORT-VESUVIUS/BILAN_AUDIT_COMPLET_V1441_V612_V72_CONCURRENT_20260219.md`) and a synchronized deep-analysis note `RAPPORT-VESUVIUS/RAPPORT_ANALYSE_PROFONDE_V1401_V1441_GITHUB_PULL_20260218.md` summarizing findings (version-stamp anomaly `v139_*`, identical artefacts, 0/255 vs 0/1 masks, neuron activations, train coverage).
- Updated `RAPPORT-VESUVIUS/analysis_v1401_v1441_deep_audit.json` and `RAPPORT-VESUVIUS/plan_roadmap_audit_inventory.json` with expanded per-notebook entries, nested ZIP/TIFF metadata, added `missing_plan_dirs` and `code_audit` counts (TODO/FIXME/pass/hardcoded paths).
- Updated the V7.5 campaign plan `RAPPORT-VESUVIUS/src_vesuvius/v7.5/PLAN_V7_5_CAMPAGNE_10_RUNS.md` to record the provided score, point out the density gap, add per-slice/ink-ratio diagnostics, and prescribe an A/B calibration matrix (low/med/high density targets) with GO/NO-GO criteria.

### Testing
- Installed TIFF tooling with `python3 -m pip install -q tifffile imagecodecs` and used a Python inspection script to open `results.zip` for V144.1, V7.5 and V61.2, extracting nested `submission.zip` and TIFF metrics (shape/dtype/min/max/mean); the script ran successfully and produced density estimates cited in the reports.
- Parsed `state.json` and `metrics.csv` from V7.5 `results.zip` using a small Python probe to validate reported `ink_ratio`, `active_neurons` and `metrics.csv` rows; the probe completed successfully and matched values in the new reports.
- Static checks: compiled selected Python modules with `python3 -m py_compile` and grepped updated Markdown files with `rg` for expected markers (scores, `ink_ratio`, `v139`, critical questions); all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699635e41fdc8323a82cfddedf40c35a)