### PR TITLE
Fix submission output format to match Kaggle AIMO3 expectations

### DIFF
--- a/RAPPORT_IAMO3/NEW IAMO3/newiamo3/nx_47_iamo3 (1).py
+++ b/RAPPORT_IAMO3/NEW IAMO3/newiamo3/nx_47_iamo3 (1).py
@@ -1564,15 +1564,15 @@ def main():
             problem_id = row.get("id", idx)
             problem_text = row.get("problem", "")
             result = solve_problem(problem_text)
-            answers.append({"id": problem_id, "prediction": int(result) if result else 0})
+            answers.append({"id": problem_id, "answer": int(result) if result else 0})
             logger.log(f"PROBLEM_{problem_id}_SOLVED: {result}")
     else:
-        answers = [{"id": 0, "prediction": 0}]
+        answers = [{"id": 0, "answer": 0}]
     
     # Export submission
     if HAS_PANDAS:
         submission_df = pd.DataFrame(answers)
-        submission_df.to_parquet("submission.parquet", index=False)
+        submission_df.to_csv("submission.csv", index=False)
         logger.log(f"SUBMISSION_EXPORTED: {len(answers)} problems")
     
     # Export des résultats complets


### PR DESCRIPTION
### Motivation
- Ensure the notebook produces the exact Kaggle AIMO3 submission schema so the pipeline can create a valid submission file for evaluation. 

### Description
- Changed only the submission formatting in `RAPPORT_IAMO3/NEW IAMO3/newiamo3/nx_47_iamo3 (1).py` by replacing the output key `prediction` with `answer` and exporting the results as `submission.csv` instead of `submission.parquet` while leaving the rest of the pipeline untouched. 

### Testing
- Ran repository sync (`git fetch origin --prune` and `git merge --ff-only origin/main`), verified the minimal diff, and checked syntax with `python -m py_compile 'RAPPORT_IAMO3/NEW IAMO3/newiamo3/nx_47_iamo3 (1).py'`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21a812068832ab953fe89e40b9702)