### PR TITLE
Add V5 forensic manifest, signing/verification tools and audit docs

### DIFF
--- a/RAPPORT_MAJ_DEPOT_DISTANT_ANALYSE_LOGS_20260228.md
+++ b/RAPPORT_MAJ_DEPOT_DISTANT_ANALYSE_LOGS_20260228.md
@@ -1,0 +1,154 @@
+# MISE À JOUR RÉELLE DU DÉPÔT DISTANT + ANALYSE DES LOGS NQubit_v4 (2026-02-28)
+
+## 1) Mise à jour du dépôt distant (GitHub)
+- Remote vérifié : `https://github.com/lumc01/Lumvorax.git`.
+- Synchronisation effectuée avec `git fetch origin --prune`.
+- Vérification du scope demandé : les artefacts `src/projetx_NQubit NX/NQubit_v4/results/*` existent bien dans `origin/main`.
+- Point important : la branche locale de travail contient un commit documentaire supplémentaire, mais la base code distante (`origin/main`) est correctement récupérée et analysée.
+
+## 2) Périmètre exact analysé (VERSION DEMANDÉE)
+Version ciblée : `src/projetx_NQubit NX/NQubit_v4`
+
+Fichiers de résultats analysés ligne par ligne :
+1. `results/nqbit_forensic_ns.log`
+2. `results/nqbit_benchmark.csv`
+3. `results/nqbit_stats_v2.csv`
+4. `results/phase_p0_p1_metrics.csv`
+5. `results/phase_p0_p1_forensic.log`
+6. `results/hardware_noise_samples_v4.csv`
+7. `results/hardware_noise_forensic_v4.log`
+8. `results/manifest_forensic_v4.json`
+9. `results/sha256_replit_v4.txt`
+10. `results/test_extended_forensic.log`
+
+## 3) Résultats concrets produits (ce que vous avez réellement obtenu)
+
+## 3.1 Performance NQubit vs baseline (benchmark principal)
+- `scenarios = 360`
+- `wins = 360`
+- `win_rate = 1.0`
+- `avg_nx_score = 0.361543481940`
+- `avg_classical_score = 0.189412669968`
+- `avg_margin = 0.172130811972`
+- `avg_energy_delta = 13.916848103278`
+
+Interprétation simple :
+- Sur ce protocole de benchmark, NQubit gagne dans 100% des cas mesurés (360/360).
+- Le gain moyen de score est substantiel dans ce périmètre.
+- Le coût énergétique simulé est aussi plus élevé côté NX (delta énergie positif), donc il y a un compromis performance/coût.
+
+## 3.2 Logs nanosecondes forensic
+- Le log `nqbit_forensic_ns.log` trace les événements en nanosecondes avec couches (`hardware`, `simulation`, `expert_review`).
+- On observe au début : détection CPU = 8, RAM détectée ≈ 62.8 GB.
+- Les événements de run consignent score NX, score classical, marge et énergie delta de manière structurée.
+
+Interprétation :
+- Ce que vous avez produit concrètement n’est pas seulement un score final ; vous avez produit une traçabilité temporelle détaillée des décisions et mesures du noyau.
+
+## 3.3 Résultats P0/P1 (comparaison protocoles)
+- `baseline_current`: +90.764% (win_rate 1.0)
+- `p0_no_lyapunov`: +34.368% (win_rate 0.840)
+- `p0_impulsive_noise`: +64.588% (win_rate 1.0)
+- `p0_symmetric_scoring`: -28.453% (win_rate 0.0)
+- `p1_strong_baseline`: -28.880% (win_rate 0.0)
+- `p1_ood_drift_heavy`: -40.799% (win_rate 0.0)
+
+Interprétation :
+- Le système est performant sur certains protocoles, mais échoue sur d’autres configurations de scoring/baseline.
+- Conclusion mature: performance forte mais non universelle, dépendante du contexte expérimental.
+
+## 3.4 Capture bruit matériel V4
+- `samples = 20000`
+- `mean = 0.001975873641`
+- `stddev = 0.577123829060`
+- `min/max = -0.999764883818 / 0.999682663364`
+- `p01/p99 = -0.978347374398 / 0.982119310538`
+
+Interprétation :
+- La distribution est centrée proche de 0 et étendue sur presque tout [-1, 1], compatible avec un bruit pseudo-uniforme capturé via le proxy matériel défini.
+- Concrètement : vous avez réussi à intégrer une source de bruit mesurée et loggée dans le pipeline V4.
+
+## 3.5 Tests étendus
+`test_extended_forensic.log` indique :
+- tier 10: 10/10
+- tier 100: 100/100
+- tier 1000: 1000/1000
+- tier 10000: 10000/10000
+- total: 11110/11110
+
+Interprétation :
+- Les tests programmés fournis dans cette version passent intégralement sur le périmètre défini.
+
+## 4) Comparaison versions précédentes (réponse aux questions déjà posées)
+
+## 4.1 V2 vs V3 vs V4 (ce que disent réellement les artefacts)
+Les fichiers `nqbit_stats_v2.csv` de V2, V3 et V4 sont numériquement identiques sur les KPI globaux listés.
+
+Ce que cela veut dire réellement :
+- La V4 n’apporte pas (dans ces CSV globaux) une augmentation directe des KPI agrégés principaux par rapport à V3/V2.
+- L’apport V4 est surtout architectural/forensic : instrumentation hardware noise, artefacts supplémentaires, traçabilité enrichie.
+
+## 4.2 Réponse directe à "qu’est-ce qui a été réussi concrètement ?"
+Vous avez réussi à produire, de façon concrète :
+1. un pipeline de simulation reproductible avec 360 scénarios gagnés dans le benchmark fourni ;
+2. une télémétrie nanoseconde exploitable pour audit ;
+3. une batterie P0/P1 qui révèle les zones de force et de faiblesse ;
+4. une capture de bruit matériel avec statistiques exploitables ;
+5. une suite de tests étendus validée (11110/11110).
+
+## 5) Anomalie critique trouvée pendant la revue des logs
+Comparaison d’intégrité entre :
+- `manifest_forensic_v4.json` (hash internes),
+- `sha256_replit_v4.txt` (hash calculés),
+- recalcul SHA256 local des fichiers.
+
+Constat :
+- Plusieurs hash de `manifest_forensic_v4.json` ne correspondent plus aux hash actuels des artefacts.
+- Les hash de `sha256_replit_v4.txt` correspondent, eux, aux fichiers présents.
+
+Interprétation :
+- Le manifest V4 est probablement obsolète (généré avant une régénération d’artefacts).
+- Pour une chaîne forensic stricte, il faut régénérer/signature unique du manifest final après gel des artefacts.
+
+## 6) Questions qu’un expert posera après lecture ligne à ligne
+
+## 6.1 Validité scientifique
+1. Quel est le protocole exact des 360 scénarios (distribution, bornes, seeds) ?
+2. Les métriques sont-elles stables sur plusieurs machines/architectures ?
+3. Pourquoi certains protocoles P0/P1 donnent 0% de win_rate ?
+4. Les CI95 sont-ils calculés sur assez de répétitions indépendantes ?
+5. Quel est l’impact exact du module bruit hardware sur le score final ?
+
+## 6.2 Intégrité forensic
+6. Pourquoi le manifest V4 diverge des hash réels actuels ?
+7. Quel artefact fait foi pour l’audit final (manifest ou sha256 list) ?
+8. Existe-t-il un mécanisme de signature (clé privée, attestations) au-delà du SHA256 ?
+9. Avez-vous un chaînage Merkle inter-runs pour prouver l’immutabilité historique ?
+
+## 6.3 Performance réelle / produit
+10. Le gain observé se maintient-il hors benchmark interne (données OOD réelles) ?
+11. Quel est le coût énergétique réel sur hardware cible, pas seulement simulé ?
+12. Quels KPI décisionnels définissent un "GO production" objectif ?
+
+## 7) Réponses actuelles et nouvelles possibilités
+
+## 7.1 Réponses actuelles (honnêtes)
+- Oui, on a une vraie instrumentation et des logs exploitables.
+- Oui, le benchmark interne montre un avantage net de NX.
+- Non, la supériorité n’est pas universelle (certaines variantes P0/P1 sont défavorables).
+- Non, l’intégrité documentaire n’est pas totalement fermée tant que le manifest n’est pas recalé sur l’état final des artefacts.
+
+## 7.2 Nouvelles possibilités (prochaines actions fortes)
+1. Régénérer `manifest_forensic_v4.json` depuis les fichiers gelés, puis signer le manifest.
+2. Ajouter un contrôle CI bloquant : "manifest hash == hash fichiers" obligatoire.
+3. Isoler les conditions où P0/P1 échoue et adapter dynamiquement la stratégie de scoring.
+4. Lancer campagne multi-machine (Replit, local, cloud dédié) pour mesurer robustesse inter-environnements.
+5. Produire un tableau décisionnel GO/NO-GO avec seuils explicites (score, variance, coût, intégrité).
+
+## 8) Conclusion claire pour vous
+En clair :
+- Vous avez effectivement construit un système V4 qui produit des résultats mesurables, des logs forensic détaillés et des tests massifs validés.
+- Vous n’avez pas seulement "du code" : vous avez un pipeline d’expérimentation instrumenté.
+- Le point à corriger pour un niveau expert/industriel est la cohérence finale de la chaîne d’intégrité (manifest vs hash actuels) et la généralisation hors benchmark interne.
+
+Donc, concrètement : **production technique réussie**, **validation scientifique avancée mais encore perfectible**, **forensic quasi mature avec un verrou d’intégrité à finaliser**.

--- a/src/projetx_NQubit NX/NQubit_v5/GUIDE_IMMEDIAT_V5_AVANT_APRES_ADC.md
+++ b/src/projetx_NQubit NX/NQubit_v5/GUIDE_IMMEDIAT_V5_AVANT_APRES_ADC.md
@@ -1,0 +1,109 @@
+# GUIDE IMMÉDIAT V5 — Quoi faire maintenant + explication ultra claire du AVANT/APRÈS ADC
+
+## 0) Réponse directe à "Donc il faut faire quoi exactement ?"
+Pour intégrer V5 **immédiatement** sans rien casser :
+1. Geler les artefacts de run (ne plus modifier les fichiers `results/` ciblés).
+2. Générer un manifest canonique V5 depuis ces artefacts.
+3. Vérifier que le manifest matche 100% des fichiers.
+4. Signer le manifest avec une clé privée d’audit.
+5. Vérifier la signature avec la clé publique.
+6. Bloquer la CI si vérification hash/signature échoue.
+
+En une phrase : **manifest signé = vérité d’audit**, CI = gardien automatique.
+
+---
+
+## 1) AVANT V5 vs APRÈS V5 (explication pédagogique)
+
+| Sujet | AVANT V5 | APRÈS V5 |
+|---|---|---|
+| Autorité d’audit | Ambiguë (manifest V4 vs sha256 list) | Claire : `manifest_forensic_v5.json` **signé** |
+| Intégrité | Hash présents mais divergence possible entre artefacts | Vérification reproductible via `verify_manifest_v5.py` |
+| Preuve d’origine | SHA256 seul (intégrité uniquement) | Signature asymétrique possible (origine + intégrité) |
+| Gouvernance | Pas de point d’ancrage unique explicite | `source_of_truth` explicite dans le manifest V5 |
+| Risque principal | Confusion en audit final si fichiers régénérés | Réduit si pipeline "générer -> vérifier -> signer -> vérifier" est respecté |
+
+### Ce que cela veut dire concrètement
+- **Avant** : on pouvait dire "les hash existent", mais pas toujours "cet ensemble est le bon ensemble final validé par l’autorité".
+- **Après** : on peut dire "cet ensemble précis est figé, vérifié, et validé par signature".
+
+---
+
+## 2) Pourquoi "ADC réel validé : NON" (ultra clair)
+
+## 2.1 Ce qu’on appelle "ADC réel validé"
+Pour dire "ADC réel validé", il faut normalement prouver :
+1. un matériel ADC physique identifié (référence, série, configuration),
+2. une calibration/documentation métrologique,
+3. un protocole de mesure répété,
+4. des résultats reproductibles inter-environnements/labs,
+5. des artefacts forensic cohérents signés.
+
+## 2.2 Ce qu’on a dans les preuves actuelles
+- Une capture de bruit via un **proxy software/hardware jitter**.
+- Des logs forensic robustes.
+- Des vérifications de pipeline logiciel.
+
+## 2.3 Pourquoi la conclusion est NON (et pas peut-être)
+- Parce que la preuve actuelle décrit surtout une chaîne logicielle instrumentée,
+- mais **pas** une chaîne ADC matérielle certifiée de bout en bout.
+
+👉 Donc :
+- **Validé côté protocole forensic logiciel : OUI**.
+- **Validé côté acquisition ADC physique réelle : NON à ce stade**.
+
+---
+
+## 3) Plan d’intégration immédiate V5 (copier-coller)
+
+## 3.1 Générer le manifest canonique
+```bash
+python 'src/projetx_NQubit NX/NQubit_v5/tools/build_manifest_v5.py' \
+  --input-dir 'src/projetx_NQubit NX/NQubit_v4/results' \
+  --output 'src/projetx_NQubit NX/NQubit_v5/results/manifest_forensic_v5.json'
+```
+
+## 3.2 Vérifier les hash du manifest
+```bash
+python 'src/projetx_NQubit NX/NQubit_v5/tools/verify_manifest_v5.py' \
+  --manifest 'src/projetx_NQubit NX/NQubit_v5/results/manifest_forensic_v5.json'
+```
+Attendu : `missing=0` et `mismatches=0`.
+
+## 3.3 Signer le manifest
+```bash
+bash 'src/projetx_NQubit NX/NQubit_v5/tools/sign_manifest_v5.sh' \
+  'src/projetx_NQubit NX/NQubit_v5/results/manifest_forensic_v5.json' \
+  '<private_key.pem>' \
+  '<public_key.pem>'
+```
+
+## 3.4 Mettre en CI (obligatoire)
+- Étape 1: exécuter `verify_manifest_v5.py`.
+- Étape 2: vérifier la signature.
+- Si une étape échoue => pipeline rouge, release bloquée.
+
+---
+
+## 4) Ce que tu peux annoncer maintenant (sans sur-promesse)
+Tu peux dire immédiatement :
+1. "V5 fixe l’autorité d’audit avec un manifest signé".
+2. "La chaîne d’intégrité est vérifiable automatiquement".
+3. "Le protocole forensic logiciel est reproductible dans le périmètre testé".
+
+Tu ne dois pas encore dire :
+- "ADC physique réel validé scientifiquement" tant que la campagne instrumentée ADC n’est pas exécutée et attestée.
+
+---
+
+## 5) Checklist de validation finale (courte)
+- [ ] Manifest V5 régénéré après gel des artefacts.
+- [ ] `verify_manifest_v5.py` => 0 mismatch.
+- [ ] Signature `.sig` générée.
+- [ ] Vérification signature OK avec clé publique.
+- [ ] CI bloque les merges si hash/signature invalides.
+- [ ] Claims publiques alignées avec le niveau de preuve réel ADC.
+
+## Conclusion opérationnelle
+V5 est prêt à être intégré **immédiatement** pour fiabiliser l’audit et l’intégrité.
+Le prochain gap scientifique à fermer reste la validation expérimentale ADC physique réelle.

--- a/src/projetx_NQubit NX/NQubit_v5/RAPPORT_V5_INTEGRITE_AUDIT_ADC_20260228.md
+++ b/src/projetx_NQubit NX/NQubit_v5/RAPPORT_V5_INTEGRITE_AUDIT_ADC_20260228.md
@@ -1,0 +1,81 @@
+# RAPPORT V5 — Intégrité d’audit, signature et statut ADC réel
+
+## 1) Réponse claire à la question 7
+**Question 7:** Quel artefact fait foi pour l’audit final (manifest ou sha256 list) ?
+
+### Réponse V5 (décision nette)
+L’artefact de référence doit être le **manifest signé** (`manifest_forensic_v5.json` + `manifest_forensic_v5.json.sig`).
+
+Pourquoi :
+- Le manifest porte l’inventaire complet des artefacts + hash + tailles.
+- Un fichier `sha256 list` seul n’a pas de statut d’autorité s’il peut être régénéré sans gouvernance.
+- La signature cryptographique du manifest permet d’authentifier l’émetteur (non-répudiation).
+
+Conclusion Q7 :
+- **Autorité finale = manifest signé**.
+- `sha256 list` = artefact de support opérationnel (debug/recalcul rapide), pas la source de vérité finale.
+
+---
+
+## 2) Réponse claire à la question 8
+**Question 8:** Existe-t-il un mécanisme de signature (clé privée, attestations) au-delà du SHA256 ?
+
+### Ce que signifie la question
+- SHA256 prouve l’intégrité de contenu (même contenu -> même hash).
+- SHA256 seul ne prouve pas *qui* a publié l’artefact.
+- Il faut une signature asymétrique (clé privée / clé publique) pour prouver l’origine.
+
+### Ce que V5 apporte
+- Script de signature : `tools/sign_manifest_v5.sh`.
+- Vérification possible de signature avec `openssl dgst -verify`.
+
+### Limite actuelle (état réel)
+- Le mécanisme est intégré côté outillage.
+- La validation complète dépend de la présence d’une vraie clé privée d’audit gérée hors dépôt.
+
+Conclusion Q8 :
+- **Oui, mécanisme au-delà du SHA256 désormais prévu/intégré en V5**.
+- **Non, la chaîne n’est pas “institutionnellement validée” tant que la gestion de clés/attestations n’est pas officiellement opérée.**
+
+---
+
+## 3) ADC réel + reproductibilité stricte du protocole : validé ou pas ?
+
+Question posée :
+> Avons-nous validé ou pas acquisition ADC réelle et reproduire exactement ce protocole avec les mêmes sorties forensic ?
+
+### Réponse factuelle
+- Dans les artefacts V4 disponibles, la capture de bruit est un **proxy logiciel/hardware jitter** (pas une acquisition ADC matérielle certifiée avec carte ADC identifiée + calibration métrologique formelle).
+- Donc la claim "ADC réel validé" ne peut pas être attestée scientifiquement à 100% avec les seules preuves actuelles.
+
+### Ce qui est validé aujourd’hui
+- Pipeline de capture et de logs fonctionne.
+- Reproductibilité logicielle du protocole forensic est forte sur l’environnement exécuté.
+
+### Ce qui n’est pas validé aujourd’hui
+- Validation métrologique d’une **chaîne ADC physique réelle** (matériel, calibration, bruit instrument, répétitions inter-lab).
+- Reproduction *exacte* cross-environment au bit près (possible variations d’horloge/virtualisation).
+
+## Verdict ADC
+- **Validation ADC réelle: NON (pas démontrée formellement).**
+- **Validation protocole forensic logiciel: OUI (dans le périmètre de test fourni).**
+
+---
+
+## 4) Correctifs V5 intégrés (sans casser l’existant)
+1. Nouveau manifest canonique V5 générable automatiquement.
+2. Vérification hash exhaustive des artefacts déclarés.
+3. Signature du manifest possible via clé privée.
+4. Rapport décisionnel clarifiant autorité d’audit et statut ADC.
+
+Aucun ancien fichier V4 n’a été écrasé/modifié pour ces correctifs V5.
+
+---
+
+## 5) Conclusion finale simple
+- Si on parle **audit final** : c’est le **manifest signé** qui doit faire foi.
+- Si on parle **preuve d’origine** : SHA256 seul ne suffit pas, il faut signature/attestation.
+- Si on parle **ADC réel validé** : pas encore validé formellement avec les preuves actuelles.
+- Si on parle **protocole forensic logiciel** : validé sur le périmètre fourni.
+
+Donc : V5 corrige le cadre d’intégrité et de gouvernance de preuve, mais l’étape scientifique ADC physique reste à valider par campagne instrumentée dédiée.

--- a/src/projetx_NQubit NX/NQubit_v5/README.md
+++ b/src/projetx_NQubit NX/NQubit_v5/README.md
@@ -1,0 +1,23 @@
+# NQubit_v5 — Correctifs d’intégrité forensic et clarification audit final
+
+Cette version V5 ajoute une chaîne d’intégrité **canonique et vérifiable** sans modifier les anciens artefacts V4.
+
+## Objectif V5
+- Définir quel artefact fait foi pour l’audit final.
+- Ajouter un mécanisme de signature au-delà du SHA256.
+- Fournir un protocole vérifiable de génération/validation de manifest.
+
+## Décision d’audit (V5)
+- Artefact qui fait foi : **`manifest_forensic_v5.json` signé**.
+- `sha256_replit_v4.txt` reste utile comme trace opérationnelle, mais n’est plus l’autorité finale.
+
+## Outils V5
+- `tools/build_manifest_v5.py` : génère le manifest canonique.
+- `tools/verify_manifest_v5.py` : vérifie tous les hash du manifest.
+- `tools/sign_manifest_v5.sh` : signe le manifest (`openssl`) et peut vérifier la signature.
+
+## Protocole recommandé
+1. Geler les artefacts de run.
+2. Générer le manifest V5.
+3. Signer le manifest avec une clé privée d’audit.
+4. Vérifier hash + signature en CI avant publication.

--- a/src/projetx_NQubit NX/NQubit_v5/results/manifest_forensic_v5.json
+++ b/src/projetx_NQubit NX/NQubit_v5/results/manifest_forensic_v5.json
@@ -1,0 +1,73 @@
+{
+  "version": "v5",
+  "generated_at_utc": "2026-02-28T20:50:01.210891+00:00",
+  "source_of_truth": "manifest_forensic_v5.json (signed)",
+  "hash_algo": "sha256",
+  "artifacts": [
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/hardware_noise_forensic_v4.log",
+      "sha256": "967ae97633a055ef253148075cdebeb4a1c12df7fd775e3386b66625f95c0837",
+      "bytes": 202
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/hardware_noise_samples_v4.csv",
+      "sha256": "75659f36604aa62eaa943bd67c682a04da57f1ecb6521b6d7c3826add39a5f25",
+      "bytes": 418938
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/manifest_forensic_v3.json",
+      "sha256": "7e365406258d951732f39af9ec1083d29b95be6baf70c9183cf1b2502079eb4a",
+      "bytes": 1614
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/manifest_forensic_v4.json",
+      "sha256": "f314bee72e00f37b33e21d4567deafbbff2de23ada014363cfba28fc2cd499a0",
+      "bytes": 2224
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/nqbit_benchmark.csv",
+      "sha256": "c92365749035b6e61ebe2ade16f8ff541a1f7d257713409a23f70e78025aecde",
+      "bytes": 35547
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/nqbit_forensic_ns.log",
+      "sha256": "a857765dd270614913993b723a071df046e3c398260066cb2f2ed981d5416d02",
+      "bytes": 163706
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/nqbit_stats_v2.csv",
+      "sha256": "423322642a41c6cb2a9086eb0ed84afa6a91d73010530b28620473397ab32fde",
+      "bytes": 347
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/phase_p0_p1_forensic.log",
+      "sha256": "036ffd05533d2dc01c9e8de2eaa37ba17ab9e8e715cef38472268149cba036cd",
+      "bytes": 1491
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/phase_p0_p1_metrics.csv",
+      "sha256": "1a078f05525e53b313b6ccaf43676a0930a59e1f3b3121616ca3b5a7039cdf55",
+      "bytes": 1037
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/rapport_final.md",
+      "sha256": "ff60646cdfae81969e6c4439262df4bf49b8d49afe1db36a8367de83d44a78d5",
+      "bytes": 780
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/replit_env_info.txt",
+      "sha256": "b9424b6f4c4b3c116978336293a77d4b8702d50ee53b7b957659d0bc061f9de2",
+      "bytes": 5271
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/sha256_replit_v4.txt",
+      "sha256": "2bc1e3ba63326527de6f1123d52dd741f61efbb34a35c26331819e0f7823589b",
+      "bytes": 1081
+    },
+    {
+      "file": "/workspace/Lumvorax/src/projetx_NQubit NX/NQubit_v4/results/test_extended_forensic.log",
+      "sha256": "e7174fb404781b8887f203a2b151b98539d35f0d8c05048884647c4bf39a983b",
+      "bytes": 269
+    }
+  ]
+}

--- a/src/projetx_NQubit NX/NQubit_v5/tools/build_manifest_v5.py
+++ b/src/projetx_NQubit NX/NQubit_v5/tools/build_manifest_v5.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description='Build canonical forensic manifest V5')
+    p.add_argument('--input-dir', required=True, help='Directory containing forensic artifacts')
+    p.add_argument('--output', required=True, help='Output manifest JSON path')
+    p.add_argument('--exclude', nargs='*', default=[], help='Basenames to exclude')
+    args = p.parse_args()
+
+    input_dir = Path(args.input_dir).resolve()
+    output = Path(args.output).resolve()
+    exclude = set(args.exclude)
+
+    files = []
+    for fp in sorted(input_dir.rglob('*')):
+        if fp.is_file() and fp.name not in exclude:
+            files.append(fp)
+
+    artifacts = []
+    for fp in files:
+        artifacts.append({
+            'file': fp.as_posix(),
+            'sha256': sha256_file(fp),
+            'bytes': fp.stat().st_size,
+        })
+
+    manifest = {
+        'version': 'v5',
+        'generated_at_utc': datetime.now(timezone.utc).isoformat(),
+        'source_of_truth': 'manifest_forensic_v5.json (signed)',
+        'hash_algo': 'sha256',
+        'artifacts': artifacts,
+    }
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
+    print(f'manifest_written={output}')
+    print(f'artifacts={len(artifacts)}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/projetx_NQubit NX/NQubit_v5/tools/sign_manifest_v5.sh
+++ b/src/projetx_NQubit NX/NQubit_v5/tools/sign_manifest_v5.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <manifest.json> <private_key.pem> [public_key.pem]"
+  exit 2
+fi
+
+manifest="$1"
+priv="$2"
+pub="${3:-}"
+
+openssl dgst -sha256 -sign "$priv" -out "${manifest}.sig" "$manifest"
+echo "signature_written=${manifest}.sig"
+
+if [[ -n "$pub" ]]; then
+  openssl dgst -sha256 -verify "$pub" -signature "${manifest}.sig" "$manifest"
+fi

--- a/src/projetx_NQubit NX/NQubit_v5/tools/verify_manifest_v5.py
+++ b/src/projetx_NQubit NX/NQubit_v5/tools/verify_manifest_v5.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description='Verify forensic manifest V5')
+    p.add_argument('--manifest', required=True)
+    args = p.parse_args()
+
+    manifest_path = Path(args.manifest)
+    data = json.loads(manifest_path.read_text(encoding='utf-8'))
+
+    mismatches = []
+    missing = []
+    for a in data.get('artifacts', []):
+        fp = Path(a['file'])
+        if not fp.exists():
+            missing.append(a['file'])
+            continue
+        actual = sha256_file(fp)
+        if actual != a['sha256']:
+            mismatches.append((a['file'], a['sha256'], actual))
+
+    print(f"artifact_count={len(data.get('artifacts', []))}")
+    print(f'missing={len(missing)}')
+    print(f'mismatches={len(mismatches)}')
+
+    for m in missing[:20]:
+        print(f'MISSING {m}')
+    for f, expected, actual in mismatches[:20]:
+        print(f'MISMATCH {f} expected={expected} actual={actual}')
+
+    return 1 if missing or mismatches else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Close an integrity gap by making a canonical signed manifest the authority for forensic artifacts after detecting divergence between the previous manifest and SHA256 lists.
- Provide reproducible tooling and clear operational guidance to generate, verify and sign a manifest and to enforce integrity in CI.
- Clarify the audit status of ADC acquisition vs the forensic software pipeline and document next steps for institutional key management.

### Description
- Add V5 artifacts and documentation: `manifest_forensic_v5.json`, `README.md`, `GUIDE_IMMEDIAT_V5_AVANT_APRES_ADC.md`, and audit report `RAPPORT_V5_INTEGRITE_AUDIT_ADC_20260228.md` under `src/projetx_NQubit NX/NQubit_v5`.
- Add tools to build, verify and sign manifests: `tools/build_manifest_v5.py`, `tools/verify_manifest_v5.py`, and `tools/sign_manifest_v5.sh` which compute SHA256, emit a canonical JSON manifest, check files for missing/mismatched hashes, and produce/verify an OpenSSL signature.
- Manifest format is `v5` JSON with `generated_at_utc`, `hash_algo` and a full `artifacts` list containing file paths, `sha256` and byte sizes, and it is intended to be the signed `source_of_truth`.
- Documented recommended process and CI policy: freeze artifacts, generate manifest, sign manifest, and fail CI if verification or signature check fails.

### Testing
- Generated the manifest with `build_manifest_v5.py` against the V4 results and the manifest file was written and committed.
- Verified the manifest with `verify_manifest_v5.py --manifest <manifest>` which reported `missing=0` and `mismatches=0` for the evaluated artifact set.
- Created and checked a signature with `sign_manifest_v5.sh <manifest> <private_key.pem> <public_key.pem>` and the verification step completed successfully.
- The existing extended forensic test artifact `test_extended_forensic.log` included in the manifest reports `11110/11110` passing tests as recorded in the results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34fc8176c83209d7df0b701050fa1)