### PR TITLE
Add V2 staging fusion module, forensic benchmark, and Replit runner for quantum simulator

### DIFF
--- a/src/advanced_calculations/quantum_simulator_v2_staging/PLAN_FUSION_V2_QUANTUM_SIMULATOR_OFFICIEL.md
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/PLAN_FUSION_V2_QUANTUM_SIMULATOR_OFFICIEL.md
@@ -1,0 +1,178 @@
+# Plan de réalisation — Fusion V2 vers le simulateur officiel `src/advanced_calculations/quantum_simulator.c`
+
+## 1) État factuel immédiat (sans invention)
+
+## 1.1 Fichiers officiels copiés en zone isolée (staging)
+Copie réalisée sans toucher aux originaux:
+- `src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.c`
+- `src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.h`
+- `src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.o`
+
+Objectif: préparer la V2 de fusion sans mélanger avec la version officielle tant que validation complète non terminée.
+
+## 1.2 Résultats/logs trouvés pour `vkernel_nqubit_v2`
+- Trouvés et versionnés:
+  - `src/quantum/vkernel_nqubit_v2/results/20260302_194455/comparison_summary_v2.json`
+  - `src/quantum/vkernel_nqubit_v2/results/20260302_194455/comparison_summary_v2.md`
+  - `src/quantum/vkernel_nqubit_v2/results/20260302_194455/nqubit_forensic_ns_v2.jsonl`
+
+## 1.3 Résultats/logs trouvés pour le simulateur officiel `src/advanced_calculations/quantum_simulator.c`
+- **Aucun artefact de run dédié, explicitement lié à `quantum_simulator.c`, n'a été trouvé dans `src/advanced_calculations/`**.
+- Le fichier de test `src/tests/test_quantum_simulator_complete.c` affiche des messages console, mais ne persiste pas de rapport/log forensic structuré.
+
+Conclusion stricte: aujourd'hui, il existe des résultats consolidés pour V2 (`src/quantum/...`), mais pas de dossier de résultats versionné équivalent prouvant des exécutions complètes du simulateur officiel `advanced_calculations/quantum_simulator.c`.
+
+---
+
+## 2) Comparaison technique — `quantum_simulator.c` officiel vs `vkernel_nqubit_v2`
+
+## 2.1 Simulateur officiel (`src/advanced_calculations/quantum_simulator.c`)
+- Modèle "qubit/LUM" avec structures riches (`quantum_lum_t`, `quantum_result_t`, `quantum_config_t`).
+- Portes quantiques de base (Hadamard, Pauli X/Z, phase).
+- Fonctions de création/destruction, mesure, stress test.
+- Intégration mémoire/forensic via `memory_tracker`/`forensic_logger` (niveau code), mais sans pipeline de run standardisé versionné dans `src/advanced_calculations/results/...`.
+
+## 2.2 Simulateur V2 (`src/quantum/vkernel_nqubit_v2/v_kernel_quantum_nx_v2.c`)
+- Benchmark dynamique multi-scénarios/multi-steps.
+- Logs forensic JSONL nanoseconde dédiés à la campagne (`scenario_margin`, `summary`).
+- KPI comparatifs directs NX vs baseline (`avg_score`, `win_rate`, `nqubits_per_sec`).
+
+## 2.3 Écart principal à combler dans la fusion
+Le module officiel possède une base de simulation plus "moteur", mais manque d'un pipeline de benchmark forensic reproductible au niveau de granularité V2 (KPI comparatifs, traces run-id, rapports auto).
+
+---
+
+## 3) Interprétation exacte de "NX gagne ~65.3%"
+
+## 3.1 Calcul concret
+- `nqubit_win_rate = 0.6527777778`
+- Sur 360 scénarios: `0.6527777778 * 360 = 235` scénarios gagnés par NX.
+- Donc `360 - 235 = 125` scénarios perdus par NX, soit **34.7222%**.
+
+## 3.2 Que représentent ces 34.7% ?
+Ils représentent les scénarios où le score baseline local (`baseline_qubit_avg_score` par scénario) dépasse le score NX.
+
+## 3.3 "Zones de fragilité": ce qui est connu vs inconnu
+- **Connu** (depuis log actuel):
+  - au moins un cas échantillonné perdant (`scenario=256`, `margin<0`).
+- **Inconnu avec certitude** (car le log actuel est échantillonné tous les 64 scénarios):
+  - la liste complète des 125 scénarios perdants,
+  - leur typologie exacte.
+
+Donc, sans nouveau run enrichi, on ne peut pas donner "toutes les zones" avec exactitude ligne par ligne.
+
+---
+
+## 4) Plan d'intégration/fusion V2 -> officiel (avant/après, sans régression)
+
+## 4.1 Objectifs non négociables
+1. Ne pas toucher à la version officielle tant que la staging V2 n'est pas validée.
+2. Zéro warning, zéro stub, zéro placeholder, zéro hardcoding caché.
+3. Ajouter des logs forensic (pas en retirer).
+4. Tests unitaires + intégration + stress élevé (objectif 99% CPU/RAM) avec preuves.
+5. Mode RNG configurable, incluant **désactivation PRNG logiciel** pour usage hardware-only quand disponible.
+
+## 4.2 Architecture de staging proposée
+Dans `src/advanced_calculations/quantum_simulator_v2_staging/`:
+- `quantum_simulator_v2.c/.h` (ou patch incrémental sur copie)
+- `tools/`:
+  - `run_compare_official_vs_v2.py`
+  - `collect_hw_entropy.py`
+  - `stress_99_resources.py`
+  - `build_manifest_v2.py`
+  - `verify_manifest_v2.py`
+- `tests/`:
+  - `test_rng_modes.c`
+  - `test_forensic_jsonl_schema.py`
+  - `test_scenario_losses_full.py`
+  - `test_stress_99_resources.py`
+- `results/<run_id>/`:
+  - `forensic_ns_full.jsonl`
+  - `comparison_summary.json`
+  - `manifest_forensic_v2.json`
+  - `verify_manifest_report.json`
+  - `resource_stress_report.json`
+
+## 4.3 Mode RNG demandé: désactivation PRNG logiciel
+Ajouter une configuration explicite:
+- `RNG_MODE=hardware_only`: interdit fallback PRNG logiciel; le run échoue proprement si aucune source hardware valide.
+- `RNG_MODE=hardware_preferred`: hardware d'abord, fallback logiciel tracé.
+- `RNG_MODE=deterministic_seeded`: mode reproductible test.
+
+Chaque run doit journaliser:
+- sources détectées (`/dev/hwrng`, `/dev/random`, `/dev/urandom`, autres API système),
+- mode choisi,
+- preuves de lecture (volume, débit, erreurs).
+
+## 4.4 Campagne avant/après (protocole strict)
+### Avant (baseline officiel)
+- Exécuter simulateur officiel inchangé.
+- Capturer KPI + logs forensic minimum.
+
+### Après (staging V2 fusion)
+- Exécuter même matrice de charge.
+- Comparer automatiquement:
+  - performance (ops/s, nqubits/s, latences p50/p95/p99),
+  - stabilité (variance inter-run),
+  - intégrité (manifest/hash),
+  - coût ressources (CPU/RAM/IO).
+
+Validation Go/No-Go:
+- pas de régression critique,
+- intégrité `true`,
+- tests >= 95% et zéro test critique en échec,
+- explication de toute anomalie.
+
+## 4.5 Logs nécessaires pour répondre aux 10 questions d'expert
+Pour répondre exactement à toutes les questions demandées:
+1. journaliser 100% des scénarios (pas seulement 1/64),
+2. exécuter au moins 30 runs multi-seed,
+3. exécuter un plan factoriel sur `sigma`, `thermal`, `lyapunov_gain`,
+4. exécuter une montée en échelle (`scenarios`, `steps` x10),
+5. tester plusieurs baselines,
+6. exporter table des scénarios perdants triés,
+7. calculer IC95 du gain,
+8. corréler gain avec coût CPU/RAM/énergie,
+9. intégrer manifest/signature au pipeline V2,
+10. publier dashboard KPI business priorisés.
+
+---
+
+## 5) Réponses demandées (version claire)
+
+## 5.1 "Comparaison avec simulateur officiel" 
+- Oui, comparaison possible conceptuellement et structurellement.
+- Non, preuve run-à-run officielle complète impossible maintenant faute d'artefacts versionnés dédiés au simulateur officiel.
+
+## 5.2 "Retrouve les résultats/logs/rapports officiels"
+- Résultat honnête: non trouvés sous une forme consolidée comparable à `vkernel_nqubit_v2/results/...`.
+
+## 5.3 "Que sont les 34% que NX ne réussit pas ?"
+- 125 scénarios perdus sur 360 dans cette campagne.
+- Leur liste exhaustive n'est pas reconstructible avec le log échantillonné actuel; il faut un run full-trace pour les identifier tous.
+
+## 5.4 "Toutes les zones de fragilité"
+- Zone confirmée: scénario 256 (marge négative).
+- Zones complètes: non déterminables sans instrumentation full per-scenario.
+
+---
+
+## 6) Plan exécutable en 6 phases
+1. **Freeze**: geler baseline officiel + métadonnées environnement.
+2. **Instrumentation**: ajouter forensic ns complet et mode RNG hardware-only dans staging.
+3. **Validation unitaire**: RNG modes, schema logs, intégrité manifest.
+4. **Stress 99%**: campagne CPU/RAM 99% avec garde-fous sécurité.
+5. **Comparaison A/B**: officiel vs staging V2 sur même protocole.
+6. **Gate final**: fusion vers officiel seulement si zéro régression critique et traçabilité complète.
+
+Ce plan est la base "avant implémentation fusion complète", sans toucher à la version officielle active.
+
+## 7) Mise à jour exécution (itération actuelle)
+- `quantum_simulator.o` a été retiré du staging (pas de binaire versionné).
+- Fusion V2 ajoutée en fichiers séparés:
+  - `quantum_simulator_fusion_v2.h`
+  - `quantum_simulator_fusion_v2.c`
+- Runner Replit ajouté:
+  - `run_on_replit.sh`
+- Commande exacte:
+  - `bash /workspace/Lumvorax/src/advanced_calculations/quantum_simulator_v2_staging/run_on_replit.sh /workspace/Lumvorax`

--- a/src/advanced_calculations/quantum_simulator_v2_staging/RAPPORT_AVANT_APRES_FUSION_V2.md
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/RAPPORT_AVANT_APRES_FUSION_V2.md
@@ -1,0 +1,54 @@
+# Rapport avant/après — fusion V2 en staging (sans toucher l'officiel)
+
+## 1) Suppression binaire demandée
+- Fichier supprimé: `src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.o`.
+- Raison: éviter les binaires versionnés et l'erreur de revue Replit/GitHub (fichier binaire non supporté en diff texte).
+
+## 2) Réintégration de l'existant (sans casser)
+Comparaison stricte avec les fichiers officiels:
+- `src/advanced_calculations/quantum_simulator.c` vs `.../staging/quantum_simulator.c`: **0 ligne de différence**.
+- `src/advanced_calculations/quantum_simulator.h` vs `.../staging/quantum_simulator.h`: **0 ligne de différence**.
+
+Conclusion: tout l'existant a été réintégré à l'identique dans la staging.
+
+## 3) Ce qui a été ajouté pour la fusion V2
+
+### 3.1 Nouveau module fusion (sans modifier l'ancien code)
+- `quantum_simulator_fusion_v2.h`
+  - ajoute `quantum_rng_mode_e`:
+    - `QUANTUM_RNG_HARDWARE_ONLY`
+    - `QUANTUM_RNG_HARDWARE_PREFERRED`
+    - `QUANTUM_RNG_DETERMINISTIC_SEEDED`
+  - ajoute `quantum_fusion_v2_summary_t` (wins/losses/win_rate/kpi débit).
+  - expose `quantum_fusion_v2_run_forensic_benchmark(...)`.
+
+- `quantum_simulator_fusion_v2.c`
+  - benchmark forensic multi-scénarios complet (log JSONL **chaque scénario**, pas échantillonné 1/64).
+  - calcule `nqubit_wins` et `baseline_wins` pour expliciter le 65.3% / 34.7%.
+  - supporte RNG hardware-only (échec explicite si aucune source hardware lisible).
+  - écrit une ligne `run_config` + lignes `scenario_margin` + ligne `summary`.
+
+### 3.2 Runner Replit exact
+- `run_on_replit.sh`
+  - trouve les fichiers staging automatiquement via `find`.
+  - compile le test unitaire existant avec la staging (sans toucher l'officiel).
+  - exécute le benchmark fusion V2 et produit:
+    - `results/fusion_forensic_full.jsonl`
+
+## 4) Commande exacte Replit (trouve le fichier puis exécute)
+Depuis n'importe où:
+
+```bash
+bash /workspace/Lumvorax/src/advanced_calculations/quantum_simulator_v2_staging/run_on_replit.sh /workspace/Lumvorax
+```
+
+Cette commande:
+1. localise automatiquement les fichiers staging,
+2. compile et exécute les tests staging,
+3. génère le log forensic JSONL complet de fusion V2.
+
+## 5) Pourquoi cette approche respecte la contrainte
+- aucun changement sur `src/advanced_calculations/quantum_simulator.c` officiel,
+- aucun changement sur `src/advanced_calculations/quantum_simulator.h` officiel,
+- fusion V2 isolée et exécutable,
+- suppression du binaire versionné.

--- a/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.c
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.c
@@ -1,0 +1,335 @@
+#include <complex.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <immintrin.h>
+
+#include "quantum_simulator.h"
+#include "../debug/memory_tracker.h"
+#include "../debug/forensic_logger.h"
+
+#ifdef MODULES_QUANTIQUES_ACTIFS
+
+// Variable atomique pour les IDs (définie ici pour éviter les erreurs de lien)
+_Atomic uint64_t lum_id_counter_atomic = 1000;
+
+// OPTIMISATION COMPLÈTE: Création LUM quantique ultra-optimisée pour 1M+ qubits
+quantum_lum_t* quantum_lum_create(int32_t x, int32_t y, size_t initial_states) {
+    if (initial_states == 0 || initial_states > QUANTUM_MAX_QUBITS) {
+        return NULL;
+    }
+    
+    // Protection contre OOM sur Replit (max 24 qubits pour simu vecteur d'état)
+    if (initial_states > 24) initial_states = 24;
+    
+    // OPTIMISATION 1: Allocation
+    quantum_lum_t* qlum = (quantum_lum_t*)malloc(sizeof(quantum_lum_t));
+    if (!qlum) return NULL;
+    memset(qlum, 0, sizeof(quantum_lum_t));
+    
+    // OPTIMISATION 2: ID ultra-rapide atomique
+    uint64_t quantum_id = atomic_fetch_add(&lum_id_counter_atomic, 1);
+    
+    // Initialisation LUM de base optimisée
+    qlum->base_lum.id = quantum_id;
+    qlum->base_lum.presence = 1;
+    qlum->base_lum.position_x = x;
+    qlum->base_lum.position_y = y;
+    qlum->base_lum.structure_type = LUM_STRUCTURE_BINARY;
+    
+    // OPTIMISATION 3: Timestamp ultra-précis
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    qlum->base_lum.timestamp = (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+    qlum->base_lum.memory_address = &qlum->base_lum;
+    qlum->base_lum.is_destroyed = 0;
+    
+    // OPTIMISATION 4: Checksum quantique spécialisé
+    qlum->base_lum.checksum = (uint32_t)(quantum_id ^ x ^ y ^ initial_states ^ 
+                                        (uint32_t)(qlum->base_lum.timestamp & 0xFFFFFFFF));
+    
+    // OPTIMISATION 5: Allocation amplitudes
+    qlum->state_count = initial_states;
+    size_t amplitudes_size = initial_states * sizeof(double complex);
+    qlum->amplitudes = (double complex*)malloc(amplitudes_size);
+    if (!qlum->amplitudes) {
+        free(qlum);
+        return NULL;
+    }
+    memset(qlum->amplitudes, 0, amplitudes_size);
+    
+    // Initialisation état |0⟩
+    qlum->amplitudes[0] = 1.0 + 0.0 * I;
+    
+    // OPTIMISATION 7: Initialisation métadonnées quantiques
+    qlum->entangled_ids = NULL;
+    qlum->entanglement_count = 0;
+    qlum->coherence_time = 1000000.0; // 1ms optimisé
+    qlum->fidelity = 1.0;
+    qlum->memory_address = (void*)qlum;
+    qlum->quantum_magic = QUANTUM_MAGIC_NUMBER;
+    qlum->is_measured = false;
+    
+    return qlum;
+}
+
+// Destruction LUM quantique
+void quantum_lum_destroy(quantum_lum_t** qlum_ptr) {
+    if (!qlum_ptr || !*qlum_ptr) return;
+    
+    quantum_lum_t* qlum = *qlum_ptr;
+    
+    // Vérification double-free
+    if (qlum->quantum_magic != QUANTUM_MAGIC_NUMBER || 
+        qlum->memory_address != (void*)qlum) {
+        return;
+    }
+    
+    if (qlum->amplitudes) {
+        free(qlum->amplitudes);
+    }
+    if (qlum->entangled_ids) {
+        TRACKED_FREE(qlum->entangled_ids);
+    }
+    
+    qlum->quantum_magic = QUANTUM_DESTROYED_MAGIC;
+    qlum->memory_address = NULL;
+    
+    free(qlum);
+    *qlum_ptr = NULL;
+}
+
+// OPTIMISATION COMPLÈTE: Application portes quantiques ultra-optimisée
+bool quantum_apply_gate(quantum_lum_t* qlum, quantum_gate_e gate, quantum_config_t* config) {
+    if (!qlum || !config || qlum->state_count < 2) return false;
+    
+    size_t amplitudes_size = qlum->state_count * sizeof(double complex);
+    double complex* new_amplitudes = (double complex*)malloc(amplitudes_size);
+    if (!new_amplitudes) return false;
+    memset(new_amplitudes, 0, amplitudes_size);
+    
+    static const double INV_SQRT2 = 0.7071067811865476;
+    static const double complex PHASE_I = 0.0 + 1.0 * I;
+    
+    switch (gate) {
+        case QUANTUM_GATE_HADAMARD: {
+            new_amplitudes[0] = (qlum->amplitudes[0] + qlum->amplitudes[1]) * INV_SQRT2;
+            new_amplitudes[1] = (qlum->amplitudes[0] - qlum->amplitudes[1]) * INV_SQRT2;
+            if (qlum->state_count > 2) {
+                memcpy(&new_amplitudes[2], &qlum->amplitudes[2], (qlum->state_count - 2) * sizeof(double complex));
+            }
+            break;
+        }
+        case QUANTUM_GATE_PAULI_X: {
+            new_amplitudes[0] = qlum->amplitudes[1];
+            new_amplitudes[1] = qlum->amplitudes[0];
+            if (qlum->state_count > 2) {
+                memcpy(&new_amplitudes[2], &qlum->amplitudes[2], (qlum->state_count - 2) * sizeof(double complex));
+            }
+            break;
+        }
+        case QUANTUM_GATE_PAULI_Z: {
+            new_amplitudes[0] = qlum->amplitudes[0];
+            new_amplitudes[1] = -qlum->amplitudes[1];
+            if (qlum->state_count > 2) {
+                memcpy(&new_amplitudes[2], &qlum->amplitudes[2], (qlum->state_count - 2) * sizeof(double complex));
+            }
+            break;
+        }
+        case QUANTUM_GATE_PHASE: {
+            new_amplitudes[0] = qlum->amplitudes[0];
+            new_amplitudes[1] = qlum->amplitudes[1] * PHASE_I;
+            if (qlum->state_count > 2) {
+                memcpy(&new_amplitudes[2], &qlum->amplitudes[2], (qlum->state_count - 2) * sizeof(double complex));
+            }
+            break;
+        }
+        default:
+            free(new_amplitudes);
+            return false;
+    }
+    
+    free(qlum->amplitudes);
+    qlum->amplitudes = new_amplitudes;
+    qlum->fidelity *= (1.0 - config->gate_error_rate);
+    
+    return true;
+}
+
+// Intrication de deux LUMs quantiques
+bool quantum_entangle_lums(quantum_lum_t* qlum1, quantum_lum_t* qlum2, quantum_config_t* config) {
+    if (!qlum1 || !qlum2 || !config) return false;
+    
+    uint64_t* new_entangled = TRACKED_MALLOC((qlum1->entanglement_count + 1) * sizeof(uint64_t));
+    if (!new_entangled) return false;
+    
+    if (qlum1->entangled_ids) {
+        memcpy(new_entangled, qlum1->entangled_ids, qlum1->entanglement_count * sizeof(uint64_t));
+        TRACKED_FREE(qlum1->entangled_ids);
+    }
+    
+    new_entangled[qlum1->entanglement_count] = qlum2->base_lum.id;
+    qlum1->entangled_ids = new_entangled;
+    qlum1->entanglement_count++;
+    
+    if (qlum1->state_count >= 2 && qlum2->state_count >= 2) {
+        double inv_sqrt2 = 1.0 / sqrt(2.0);
+        qlum1->amplitudes[0] = inv_sqrt2;
+        qlum1->amplitudes[1] = 0.0;
+        qlum2->amplitudes[0] = 0.0;
+        qlum2->amplitudes[1] = inv_sqrt2;
+    }
+    
+    return true;
+}
+
+// Mesure quantique avec collapse
+quantum_result_t* quantum_measure(quantum_lum_t* qlum, quantum_config_t* config) {
+    if (!qlum || !config) return NULL;
+    
+    quantum_result_t* result = TRACKED_MALLOC(sizeof(quantum_result_t));
+    if (!result) return NULL;
+    memset(result, 0, sizeof(quantum_result_t));
+    
+    result->memory_address = (void*)result;
+    result->success = true;
+    result->quantum_operations = 1;
+    
+    result->probabilities = TRACKED_MALLOC(qlum->state_count * sizeof(double));
+    if (!result->probabilities) {
+        TRACKED_FREE(result);
+        return NULL;
+    }
+    
+// OPTIMISATION PRÉCISION: Calcul de probabilité haute-fidélité
+    long double total_prob = 0.0L;
+    for (size_t i = 0; i < qlum->state_count; i++) {
+        long double complex amp = (long double complex)qlum->amplitudes[i];
+        long double prob = creall(amp) * creall(amp) +
+                          cimagl(amp) * cimagl(amp);
+        result->probabilities[i] = (double)prob;
+        total_prob += prob;
+    }
+    
+    for (size_t i = 0; i < qlum->state_count; i++) {
+        result->probabilities[i] /= (double)(total_prob > 0 ? total_prob : 1.0L);
+    }
+    
+    double random = (double)rand() / RAND_MAX;
+    double cumulative = 0.0;
+    size_t measured_state = 0;
+    
+    for (size_t i = 0; i < qlum->state_count; i++) {
+        cumulative += result->probabilities[i];
+        if (random <= cumulative) {
+            measured_state = i;
+            break;
+        }
+    }
+    
+    for (size_t i = 0; i < qlum->state_count; i++) {
+        qlum->amplitudes[i] = (i == measured_state) ? 1.0 + 0.0 * I : 0.0 + 0.0 * I;
+    }
+    
+    qlum->is_measured = true;
+    result->state_count = qlum->state_count;
+    strcpy(result->error_message, "Quantum measurement completed successfully");
+    
+    return result;
+}
+
+// Tests stress
+bool quantum_stress_test_100m_qubits(quantum_config_t* config) {
+    if (!config) return false;
+    printf("=== QUANTUM STRESS TEST ===\n");
+    quantum_lum_t* q = quantum_lum_create(0, 0, 2);
+    if (q) {
+        printf("✅ Quantum LUM creation test passed\n");
+        quantum_lum_destroy(&q);
+        return true;
+    }
+    return false;
+}
+
+#endif // MODULES_QUANTIQUES_ACTIFS
+
+quantum_config_t* quantum_config_create_default(void) {
+    quantum_config_t* config = TRACKED_MALLOC(sizeof(quantum_config_t));
+    if (!config) return NULL;
+    memset(config, 0, sizeof(quantum_config_t));
+    config->decoherence_rate = 1e-6;
+    config->gate_error_rate = 1e-4;
+    config->enable_noise_model = false;
+    config->max_entanglement = 64;
+    config->use_gpu_acceleration = false;
+    config->temperature_kelvin = 0.015;
+    config->memory_address = (void*)config;
+    return config;
+}
+
+void quantum_config_destroy(quantum_config_t** config_ptr) {
+    if (!config_ptr || !*config_ptr) return;
+    quantum_config_t* config = *config_ptr;
+    if (config->memory_address == (void*)config) {
+        TRACKED_FREE(config);
+        *config_ptr = NULL;
+    }
+}
+
+void quantum_result_destroy(quantum_result_t** result_ptr) {
+    if (!result_ptr || !*result_ptr) return;
+    quantum_result_t* result = *result_ptr;
+    if (result->memory_address == (void*)result) {
+        if (result->probabilities) TRACKED_FREE(result->probabilities);
+        if (result->state_vector) TRACKED_FREE(result->state_vector);
+        TRACKED_FREE(result);
+        *result_ptr = NULL;
+    }
+}
+
+quantum_simulator_t* quantum_simulator_create(size_t qubit_count, quantum_config_t* config) {
+    if (qubit_count == 0 || qubit_count > QUANTUM_MAX_QUBITS || !config) return NULL;
+    quantum_simulator_t* simulator = TRACKED_MALLOC(sizeof(quantum_simulator_t));
+    if (!simulator) return NULL;
+    memset(simulator, 0, sizeof(quantum_simulator_t));
+    simulator->qubit_count = qubit_count;
+    simulator->config = config;
+    simulator->is_initialized = true;
+    simulator->memory_address = (void*)simulator;
+    simulator->magic_number = QUANTUM_MAGIC_NUMBER;
+    return simulator;
+}
+
+void quantum_simulator_destroy(quantum_simulator_t** simulator_ptr) {
+    if (!simulator_ptr || !*simulator_ptr) return;
+    quantum_simulator_t* simulator = *simulator_ptr;
+    if (simulator->magic_number == QUANTUM_MAGIC_NUMBER) {
+        simulator->magic_number = QUANTUM_DESTROYED_MAGIC;
+        TRACKED_FREE(simulator);
+        *simulator_ptr = NULL;
+    }
+}
+
+quantum_circuit_t* quantum_circuit_create(size_t qubit_count, size_t max_gates) {
+    if (qubit_count == 0 || max_gates == 0) return NULL;
+    quantum_circuit_t* circuit = TRACKED_MALLOC(sizeof(quantum_circuit_t));
+    if (!circuit) return NULL;
+    memset(circuit, 0, sizeof(quantum_circuit_t));
+    circuit->qubit_count = qubit_count;
+    circuit->memory_address = (void*)circuit;
+    return circuit;
+}
+
+void quantum_circuit_destroy(quantum_circuit_t** circuit_ptr) {
+    if (!circuit_ptr || !*circuit_ptr) return;
+    quantum_circuit_t* circuit = *circuit_ptr;
+    if (circuit->memory_address == (void*)circuit) {
+        TRACKED_FREE(circuit);
+        *circuit_ptr = NULL;
+    }
+}

--- a/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.h
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.h
@@ -1,0 +1,137 @@
+#ifndef QUANTUM_SIMULATOR_H
+#define QUANTUM_SIMULATOR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <complex.h>
+#include <stddef.h>
+
+#include "../common/common_types.h"
+#include "../lum/lum_core.h"
+
+// Module Simulateur Quantique pour LUM/VORAX
+// Conforme prompt.txt - nouveau module calculs avancés
+
+// LUM Quantique avec superposition et intrication
+typedef struct {
+    lum_t base_lum;                // LUM de base
+    double complex* amplitudes;   // Amplitudes quantiques (superposition)
+    size_t state_count;           // Nombre d'états superposés
+    uint64_t* entangled_ids;      // IDs des LUMs intriqués
+    size_t entanglement_count;    // Nombre d'intrications
+    double coherence_time;        // Temps de cohérence (ns)
+    double fidelity;              // Fidélité quantique [0,1]
+    void* memory_address;         // Protection double-free OBLIGATOIRE
+    uint32_t quantum_magic;       // Validation intégrité quantique
+    bool is_measured;             // État mesuré (collapse)
+} quantum_lum_t;
+
+// Portes quantiques implémentées
+typedef enum {
+    QUANTUM_GATE_HADAMARD = 0,    // Porte Hadamard (superposition)
+    QUANTUM_GATE_PAULI_X = 1,     // Porte Pauli-X (NOT quantique)
+    QUANTUM_GATE_PAULI_Y = 2,     // Porte Pauli-Y
+    QUANTUM_GATE_PAULI_Z = 3,     // Porte Pauli-Z
+    QUANTUM_GATE_CNOT = 4,        // Porte CNOT (intrication)
+    QUANTUM_GATE_PHASE = 5,       // Porte de phase
+    QUANTUM_GATE_T = 6,           // Porte T (π/8)
+    QUANTUM_GATE_S = 7,           // Porte S (π/4)
+    QUANTUM_GATE_TOFFOLI = 8      // Porte Toffoli (3-qubits)
+} quantum_gate_e;
+
+// Circuit quantique
+typedef struct {
+    quantum_lum_t** qubits;       // Array de qubits quantiques
+    size_t qubit_count;           // Nombre de qubits
+    quantum_gate_e* gate_sequence;// Séquence de portes
+    size_t gate_count;            // Nombre de portes
+    size_t* gate_targets;         // Qubits cibles pour chaque porte
+    size_t* gate_controls;        // Qubits de contrôle
+    double total_coherence;       // Cohérence totale du circuit
+    void* memory_address;         // Protection double-free OBLIGATOIRE
+    uint64_t execution_time_ns;   // Temps d'exécution nanoseconde
+} quantum_circuit_t;
+
+// Résultat simulation quantique
+typedef struct {
+    quantum_lum_t** final_states; // États finaux des qubits
+    size_t state_count;           // Nombre d'états finaux
+    double* probabilities;        // Probabilités de chaque état
+    double complex* state_vector; // Vecteur d'état complet
+    size_t vector_size;           // Taille du vecteur d'état
+    double fidelity_loss;         // Perte de fidélité durant simulation
+    bool success;                 // Succès simulation
+    char error_message[256];      // Message d'erreur
+    uint64_t quantum_operations;  // Nombre d'opérations quantiques
+    void* memory_address;         // Protection double-free OBLIGATOIRE
+} quantum_result_t;
+
+// Configuration simulateur quantique
+typedef struct {
+    double decoherence_rate;      // Taux de décohérence (1/ns)
+    double gate_error_rate;       // Taux d'erreur des portes [0,1]
+    bool enable_noise_model;      // Modèle de bruit quantique
+    size_t max_entanglement;      // Intrication maximale
+    bool use_gpu_acceleration;    // Accélération GPU
+    double temperature_kelvin;    // Température du système (mK)
+    void* memory_address;         // Protection double-free OBLIGATOIRE
+} quantum_config_t;
+
+// Simulateur quantique complet
+typedef struct {
+    size_t qubit_count;           // Nombre de qubits
+    size_t max_gates;             // Nombre maximum de portes
+    size_t state_vector_size;     // Taille du vecteur d'état
+    quantum_circuit_t* circuit;  // Circuit quantique associé
+    quantum_config_t* config;    // Configuration du simulateur
+    double* state_probabilities;  // Probabilités des états
+    bool is_initialized;          // État d'initialisation
+    void* memory_address;         // Protection double-free OBLIGATOIRE
+    uint32_t magic_number;        // Protection intégrité
+} quantum_simulator_t;
+
+// Fonctions principales
+quantum_lum_t* quantum_lum_create(int32_t x, int32_t y, size_t initial_states);
+void quantum_lum_destroy(quantum_lum_t** qlum_ptr);
+quantum_circuit_t* quantum_circuit_create(size_t qubit_count, size_t max_gates);
+void quantum_circuit_destroy(quantum_circuit_t** circuit_ptr);
+
+// Fonctions simulateur quantique
+quantum_simulator_t* quantum_simulator_create(size_t qubit_count, quantum_config_t* config);
+void quantum_simulator_destroy(quantum_simulator_t** simulator_ptr);
+
+// Opérations quantiques de base
+bool quantum_apply_gate(quantum_lum_t* qlum, quantum_gate_e gate, quantum_config_t* config);
+bool quantum_entangle_lums(quantum_lum_t* qlum1, quantum_lum_t* qlum2, quantum_config_t* config);
+quantum_result_t* quantum_measure(quantum_lum_t* qlum, quantum_config_t* config);
+bool quantum_create_superposition(quantum_lum_t* qlum, double* amplitudes, size_t state_count);
+
+// Simulation de circuits
+quantum_result_t* quantum_simulate_circuit(quantum_circuit_t* circuit, quantum_config_t* config);
+bool quantum_add_gate_to_circuit(quantum_circuit_t* circuit, quantum_gate_e gate, size_t target, size_t control);
+
+// Algorithmes quantiques avancés
+quantum_result_t* quantum_shor_algorithm(uint64_t number_to_factor, quantum_config_t* config);
+quantum_result_t* quantum_grover_search(lum_group_t* search_space, lum_t* target, quantum_config_t* config);
+quantum_result_t* quantum_quantum_fourier_transform(quantum_circuit_t* circuit, quantum_config_t* config);
+
+// Tests stress 100M+ LUMs quantiques
+bool quantum_stress_test_100m_qubits(quantum_config_t* config);
+quantum_result_t* quantum_benchmark_entanglement(size_t qubit_count, quantum_config_t* config);
+quantum_result_t* quantum_test_decoherence_scaling(size_t max_qubits, quantum_config_t* config);
+
+// Utilitaires
+quantum_config_t* quantum_config_create_default(void);
+void quantum_config_destroy(quantum_config_t** config_ptr);
+void quantum_result_destroy(quantum_result_t** result_ptr);
+double quantum_calculate_fidelity(quantum_lum_t* qlum_ideal, quantum_lum_t* qlum_actual);
+bool quantum_validate_state_vector(double complex* state_vector, size_t size);
+
+// Constantes quantiques
+#define QUANTUM_MAX_QUBITS 64
+#define QUANTUM_MIN_FIDELITY 0.95
+#define QUANTUM_PLANCK_CONSTANT 6.62607015e-34
+#define QUANTUM_MAGIC_NUMBER 0x51554E54
+#define QUANTUM_DESTROYED_MAGIC 0xDEADBEEF
+
+#endif // QUANTUM_SIMULATOR_H

--- a/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.c
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.c
@@ -1,0 +1,174 @@
+#define _POSIX_C_SOURCE 200809L
+#include "quantum_simulator_fusion_v2.h"
+
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static uint64_t now_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static uint64_t xorshift64(uint64_t* state) {
+    uint64_t x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    return x;
+}
+
+static bool seed_from_hardware(uint64_t* out_seed) {
+    const char* paths[] = {"/dev/hwrng", "/dev/random", "/dev/urandom"};
+    for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); ++i) {
+        FILE* f = fopen(paths[i], "rb");
+        if (!f) {
+            continue;
+        }
+        uint64_t seed = 0;
+        size_t rd = fread(&seed, 1, sizeof(seed), f);
+        fclose(f);
+        if (rd == sizeof(seed) && seed != 0) {
+            *out_seed = seed;
+            return true;
+        }
+    }
+    return false;
+}
+
+static double uniform01(uint64_t* state) {
+    const uint64_t value = xorshift64(state);
+    return (double)(value >> 11) * (1.0 / 9007199254740992.0);
+}
+
+static double gaussian(uint64_t* state, double sigma) {
+    const double u1 = fmax(uniform01(state), 1e-12);
+    const double u2 = uniform01(state);
+    const double radius = sqrt(-2.0 * log(u1));
+    const double theta = 6.28318530717958647692 * u2;
+    return sigma * radius * cos(theta);
+}
+
+bool quantum_fusion_v2_run_forensic_benchmark(
+    const char* output_jsonl,
+    size_t scenarios,
+    size_t steps,
+    quantum_rng_mode_e rng_mode,
+    uint64_t seed,
+    quantum_fusion_v2_summary_t* out_summary
+) {
+    if (!output_jsonl || scenarios == 0 || steps == 0 || !out_summary) {
+        return false;
+    }
+
+    FILE* logf = fopen(output_jsonl, "w");
+    if (!logf) {
+        return false;
+    }
+
+    uint64_t rng_nx = seed;
+    uint64_t rng_q = seed ^ 0x9E3779B97F4A7C15ULL;
+    bool used_hw = false;
+
+    if (rng_mode == QUANTUM_RNG_HARDWARE_ONLY || rng_mode == QUANTUM_RNG_HARDWARE_PREFERRED) {
+        uint64_t hw_seed = 0;
+        const bool hw_ok = seed_from_hardware(&hw_seed);
+        if (!hw_ok && rng_mode == QUANTUM_RNG_HARDWARE_ONLY) {
+            fclose(logf);
+            return false;
+        }
+        if (hw_ok) {
+            rng_nx = hw_seed;
+            rng_q = hw_seed ^ 0xA5A5A5A55A5A5A5AULL;
+            used_hw = true;
+        }
+    }
+
+    if (rng_nx == 0) rng_nx = 0xC0FFEE12345678ULL;
+    if (rng_q == 0) rng_q = 0xABCDEF456789ULL;
+
+    const uint64_t t0_ns = now_ns();
+    double nx_total_score = 0.0;
+    double q_total_score = 0.0;
+    size_t nx_wins = 0U;
+
+    fprintf(logf,
+            "{\"event\":\"run_config\",\"rng_mode\":%d,\"used_hardware_entropy\":%s,\"scenarios\":%zu,\"steps\":%zu}\n",
+            (int)rng_mode,
+            used_hw ? "true" : "false",
+            scenarios,
+            steps);
+
+    for (size_t i = 0; i < scenarios; ++i) {
+        double nx_state = -1.5 + 3.0 * ((double)i / (double)scenarios);
+        double q_state = nx_state;
+        const double target = 0.7 + 0.4 * (double)(i % 11U) / 10.0;
+        const double sigma = 0.02 + 0.001 * (double)(i % 20U);
+        const double thermal = 1.0 + 0.02 * (double)(i % 15U);
+        const double lyapunov_gain = 0.25;
+
+        for (size_t s = 0; s < steps; ++s) {
+            const double noise_nx = gaussian(&rng_nx, sigma * thermal);
+            const double grad = target - nx_state;
+            nx_state += noise_nx + lyapunov_gain * tanh(grad);
+
+            const double noise_q = gaussian(&rng_q, sigma * 0.7);
+            q_state += 0.03 * (target - q_state) + noise_q;
+        }
+
+        const double nx_score = 1.0 / (1.0 + fabs(target - nx_state));
+        const double q_score = 1.0 / (1.0 + fabs(target - q_state));
+        nx_total_score += nx_score;
+        q_total_score += q_score;
+        if (nx_score > q_score) nx_wins++;
+
+        const uint64_t t_ns = now_ns();
+        fprintf(logf,
+                "{\"ts_ns\":%llu,\"delta_ns\":%llu,\"event\":\"scenario_margin\",\"scenario\":%zu,\"margin\":%.12f}\n",
+                (unsigned long long)t_ns,
+                (unsigned long long)(t_ns - t0_ns),
+                i,
+                nx_score - q_score);
+    }
+
+    const uint64_t t1_ns = now_ns();
+    const uint64_t elapsed_ns = t1_ns - t0_ns;
+    const double elapsed_s = (double)elapsed_ns / 1e9;
+    const double nqubits_simulated = (double)(scenarios * steps);
+    const double nqubits_per_sec = nqubits_simulated / (elapsed_s > 0.0 ? elapsed_s : 1e-12);
+    const double nx_avg = nx_total_score / (double)scenarios;
+    const double q_avg = q_total_score / (double)scenarios;
+    const double win_rate = (double)nx_wins / (double)scenarios;
+
+    fprintf(logf,
+            "{\"event\":\"summary\",\"nqubits_simulated\":%.0f,\"nqubits_per_sec\":%.3f,\"elapsed_ns\":%llu,\"nqubit_avg_score\":%.12f,\"baseline_qubit_avg_score\":%.12f,\"nqubit_win_rate\":%.12f,\"nqubit_wins\":%zu,\"baseline_wins\":%zu}\n",
+            nqubits_simulated,
+            nqubits_per_sec,
+            (unsigned long long)elapsed_ns,
+            nx_avg,
+            q_avg,
+            win_rate,
+            nx_wins,
+            scenarios - nx_wins);
+
+    fclose(logf);
+
+    memset(out_summary, 0, sizeof(*out_summary));
+    out_summary->scenarios = scenarios;
+    out_summary->steps = steps;
+    out_summary->nqubits_simulated = nqubits_simulated;
+    out_summary->nqubits_per_sec = nqubits_per_sec;
+    out_summary->nqubit_avg_score = nx_avg;
+    out_summary->baseline_qubit_avg_score = q_avg;
+    out_summary->nqubit_win_rate = win_rate;
+    out_summary->nqubit_wins = nx_wins;
+    out_summary->baseline_wins = scenarios - nx_wins;
+    out_summary->elapsed_ns = elapsed_ns;
+    out_summary->used_hardware_entropy = used_hw;
+    return true;
+}

--- a/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.h
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.h
@@ -1,0 +1,39 @@
+#ifndef QUANTUM_SIMULATOR_FUSION_V2_H
+#define QUANTUM_SIMULATOR_FUSION_V2_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "quantum_simulator.h"
+
+typedef enum {
+    QUANTUM_RNG_HARDWARE_ONLY = 0,
+    QUANTUM_RNG_HARDWARE_PREFERRED = 1,
+    QUANTUM_RNG_DETERMINISTIC_SEEDED = 2
+} quantum_rng_mode_e;
+
+typedef struct {
+    size_t scenarios;
+    size_t steps;
+    double nqubits_simulated;
+    double nqubits_per_sec;
+    double nqubit_avg_score;
+    double baseline_qubit_avg_score;
+    double nqubit_win_rate;
+    size_t nqubit_wins;
+    size_t baseline_wins;
+    uint64_t elapsed_ns;
+    bool used_hardware_entropy;
+} quantum_fusion_v2_summary_t;
+
+bool quantum_fusion_v2_run_forensic_benchmark(
+    const char* output_jsonl,
+    size_t scenarios,
+    size_t steps,
+    quantum_rng_mode_e rng_mode,
+    uint64_t seed,
+    quantum_fusion_v2_summary_t* out_summary
+);
+
+#endif

--- a/src/advanced_calculations/quantum_simulator_v2_staging/run_on_replit.sh
+++ b/src/advanced_calculations/quantum_simulator_v2_staging/run_on_replit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-/workspace/Lumvorax}"
+TARGET_C="$(find "$ROOT" -type f -path '*/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.c' | head -n 1)"
+FUSION_C="$(find "$ROOT" -type f -path '*/src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.c' | head -n 1)"
+if [[ -z "$TARGET_C" || -z "$FUSION_C" ]]; then
+  echo "Erreur: fichiers staging introuvables sous $ROOT" >&2
+  exit 2
+fi
+REPO_ROOT="$(cd "$(dirname "$TARGET_C")/../../.." && pwd)"
+OUT_DIR="$REPO_ROOT/src/advanced_calculations/quantum_simulator_v2_staging/results"
+mkdir -p "$OUT_DIR"
+OUT_BIN="$OUT_DIR/qs_v2_staging_test"
+OUT_JSONL="$OUT_DIR/fusion_forensic_full.jsonl"
+
+pushd "$REPO_ROOT" >/dev/null
+
+gcc -DMODULES_QUANTIQUES_ACTIFS -I./src -I./src/advanced_calculations -I./src/common -I./src/lum \
+  src/tests/test_quantum_simulator_complete.c \
+  src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator.c \
+  src/debug/memory_tracker.c src/debug/forensic_logger.c src/lum/lum_core.c \
+  -lm -o "$OUT_BIN"
+
+"$OUT_BIN"
+
+cat > "$OUT_DIR/fusion_runner.c" <<'RUNEOF'
+#include <stdio.h>
+#include "../quantum_simulator_fusion_v2.h"
+int main(void){
+  quantum_fusion_v2_summary_t s;
+  if(!quantum_fusion_v2_run_forensic_benchmark("results/fusion_forensic_full.jsonl",360,1400,QUANTUM_RNG_HARDWARE_PREFERRED,0xC0FFEEu,&s)){
+    fprintf(stderr,"fusion benchmark failed\n");
+    return 1;
+  }
+  printf("wins=%zu losses=%zu win_rate=%.9f nqubits_per_sec=%.3f hw_entropy=%s\n",
+    s.nqubit_wins,s.baseline_wins,s.nqubit_win_rate,s.nqubits_per_sec,s.used_hardware_entropy?"true":"false");
+  return 0;
+}
+RUNEOF
+
+gcc -I./src -I./src/advanced_calculations -I./src/common -I./src/lum \
+  src/advanced_calculations/quantum_simulator_v2_staging/results/fusion_runner.c \
+  src/advanced_calculations/quantum_simulator_v2_staging/quantum_simulator_fusion_v2.c \
+  -lm -o "$OUT_DIR/fusion_runner"
+
+( cd src/advanced_calculations/quantum_simulator_v2_staging && ./results/fusion_runner )
+
+popd >/dev/null
+
+echo "OK: binary test + fusion run terminés"
+echo "JSONL: $OUT_JSONL"

--- a/src/quantum/ANALYSE_VKERNEL_NQUBIT_V2_ET_V6_20260302.md
+++ b/src/quantum/ANALYSE_VKERNEL_NQUBIT_V2_ET_V6_20260302.md
@@ -1,0 +1,119 @@
+# Analyse consolidée — résultats distants, logs V2, comparaison V6 et statut du plan
+
+## 1) Mise à jour dépôt distant (GitHub)
+- Dépôt distant ciblé: `https://github.com/lumc01/Lumvorax.git`.
+- Synchronisation effectuée via `git fetch origin --prune`.
+- Constat: branche locale `work` alignée avec `origin/main` (0 commit d'écart dans les deux sens).
+
+## 2) Résultats effectivement générés pour `src/quantum/vkernel_nqubit_v2`
+
+### 2.1 Résumé chiffré (run `20260302_194455`)
+- `nqubits_simulated`: **504000** (360 scénarios x 1400 pas).
+- `nqubits_per_sec`: **13 330 519.113**.
+- `elapsed_ns`: **37 807 980 ns** (~37.8 ms).
+- `nqubit_avg_score`: **0.960970600**.
+- `baseline_qubit_avg_score`: **0.940176696**.
+- `nqubit_win_rate`: **0.652777778** (NX gagne ~65.3% des scénarios).
+- `ratio_nqubit_vs_baseline_proxy`: **168000.0** (proxy de volumétrie par rapport au baseline historique basé sur lignes de métriques).
+
+### 2.2 Interprétation concrète (ce que cela veut dire réellement)
+Ce run démontre, de manière concrète et reproductible, que:
+1. Le simulateur V2 exécute une campagne multi-scénarios dense (504k itérations de dynamique interne) rapidement.
+2. La variante NX (nqubit) surpasse la référence qubit de ce benchmark interne en score moyen.
+3. L'avantage n'est pas absolu (win rate < 100%), ce qui est sain: il existe des cas où la baseline locale reste meilleure.
+
+Important: cela valide une **supériorité dans CE protocole de simulation**, pas une preuve de "quantique matériel réel".
+
+## 3) Lecture ligne par ligne du log forensic V2 (`nqubit_forensic_ns_v2.jsonl`)
+
+### 3.1 Lignes d'événements `scenario_margin`
+- Les lignes `scenario=0,64,128,192,256,320` sont des points d'échantillonnage périodiques (tous les 64 scénarios).
+- `delta_ns` montre la progression temporelle cumulée depuis le début d'exécution.
+- `margin` = `nqubit_score - baseline_score`.
+  - Marges positives observées: scénarios 0, 64, 128, 192, 320.
+  - Marge négative observée: scénario 256 (`-0.018772675840`), signalant un cas local de sous-performance NX.
+
+### 3.2 Ligne `summary`
+- Condense les KPI globaux de la campagne.
+- Sert de vérité de synthèse pour le rapport JSON/MD.
+- Les valeurs concordent avec `comparison_summary_v2.json`.
+
+### 3.3 Sens expert
+- La présence d'une marge négative ponctuelle + win rate à 65% suggère un modèle amélioré mais encore perfectible (zones de fragilité).
+- Le débit élevé (`nqubits_per_sec`) et le temps total court indiquent que la campagne est adaptée à l'exploration rapide de variantes.
+
+## 4) Réponses aux questions "version précédente" (`nqubit_v6_integration`) et articulation avec V2
+
+Le rapport V6 précédent concluait surtout à une réussite d'industrialisation pipeline (A→Z, manifest, vérification d'intégrité, stress, fallback entropy) et non à une preuve de quantique physique.
+
+### 4.1 Ce que V2 confirme par rapport à V6
+- V6 répondait à la question "la chaîne d'exécution est-elle robuste et audit-able ?".
+- V2 répond davantage à "la dynamique nqubit bat-elle la baseline dans un benchmark contrôlé ?".
+
+### 4.2 Ce que V2 n'annule pas
+- V2 ne remplace pas les garanties forensic/manifest de V6.
+- V2 complète V6: V6 = robustesse opérationnelle; V2 = signal de gain algorithmique dans un test dédié.
+
+## 5) Différences technologiques: `src/quantum/v_kernel_quantum.c` vs nouveau simulateur V2
+
+## 5.1 Simulateur d'origine (`v_kernel_quantum.c`)
+- Prototype minimal.
+- Génère 3 métriques pseudo-aléatoires (`ENTANGLEMENT_DENSITY`, `HARDWARE_CPU_LOAD_PERCENT`, `HARDWARE_MEM_LATENCY_NS`).
+- Log en texte simple append (`hardware_metrics.log`).
+- Pas de notion de scénario/pas de temps, pas de score comparatif, pas de forensic JSONL.
+
+## 5.2 Simulateur V2 (`v_kernel_quantum_nx_v2.c`)
+- Simulation structurée multi-scénarios / multi-steps (paramétrable).
+- Horloge monotonic ns (`clock_gettime`) et sortie JSONL forensic.
+- Modèle stochastique (PRNG xorshift + bruit gaussien Box-Muller).
+- Boucle comparative NX vs baseline qubit à chaque scénario.
+- KPI finaux: débit `nqubits_per_sec`, score moyen NX, score moyen baseline, taux de victoire.
+
+## 5.3 Conséquence produit
+- On est passé d'un "générateur de métriques demo" à un "micro-benchmark de dynamique comparative nqubit".
+- Valeur concrète produite: capacité à mesurer rapidement et quantitativement des variantes de dynamique simulée.
+
+## 6) Découvertes et anomalies observées
+
+### 6.1 Découvertes (niveau: opérationnel)
+1. Gain moyen NX sur baseline dans le run observé (score moyen + win rate majoritaire).
+2. Débit très élevé permettant campagnes rapides de calibration.
+3. Instrumentation ns exploitable pour analyse temporelle fine.
+
+### 6.2 Anomalies / points d'attention
+1. `margin` négative à certains scénarios (ex: 256), donc hétérogénéité des gains.
+2. `/dev/hwrng` absent côté environnement (dans l'écosystème V6), fallback nécessaire et déjà géré.
+3. Le `ratio_nqubit_vs_baseline_proxy` dépend d'un proxy baseline rudimentaire (lignes métriques) et ne doit pas être sur-interprété scientifiquement.
+
+## 7) Le plan `PLAN_ANALYSE_INTEGRATION_V6_NQUBIT_SIMULATEUR.md` est-il réalisé à 100% ?
+Réponse stricte: **non, pas 100%**.
+
+### 7.1 Points clairement réalisés
+- Intégration V6 dédiée dans `src/quantum/nqubit_v6_integration/`.
+- Pipeline A→Z outillé (collect/acquire/stress/manifest/verify/report).
+- Tests unitaires/intégration présents dans le module V6.
+- Comparaison source/intégration outillée.
+
+### 7.2 Points partiels / non démontrés à 100%
+- Contrôle du bruit NX (Lyapunov / dissipation / stochastic resonance) annoncé dans le plan mais pas démontré de bout en bout via preuves consolidées dans les artefacts V2/V6 fournis ici.
+- Critères de validation avancés (ex: gains p95/p99 robustes multi-environnements) non couverts exhaustivement par les seules sorties versionnées actuelles.
+
+Conclusion: exécution **très avancée** du plan d'intégration opérationnelle, mais **100% non atteint** pour le volet recherche avancée et validation scientifique exhaustive.
+
+## 8) Questions qu'un expert poserait après lecture log par log
+1. Quelle est la variance inter-run de `nqubit_avg_score` et `nqubit_win_rate` sur 30+ runs ?
+2. Les résultats restent-ils stables si on change les seeds PRNG ?
+3. Quelle sensibilité du gain à `sigma`, `thermal`, `lyapunov_gain` ?
+4. Le gain persiste-t-il quand on augmente `scenarios`/`steps` d'un ordre de grandeur ?
+5. Existe-t-il un biais dans la définition de la baseline (bruit `sigma*0.7`, drift `0.03`) ?
+6. Quels scénarios exacts perdent le plus (au-delà de l'échantillonnage tous les 64) ?
+7. Quel est l'intervalle de confiance du gain moyen observé ?
+8. Le coût énergétique/CPU du gain est-il acceptable en production ?
+9. Le pipeline V2 doit-il intégrer manifest/signature comme V6 pour audit long terme ?
+10. Quel KPI business final prime: vitesse brute, stabilité, reproductibilité, ou robustesse forensic ?
+
+## 9) Réponses rapides aux nouvelles possibilités
+- Oui, possibilité d'unifier V2 + V6 (benchmark algorithmique + forensic complet).
+- Oui, possibilité d'un protocole A/B multi-seed et multi-environnements pour solidifier la validité.
+- Oui, possibilité d'ajouter p50/p95/p99 et tests de régression automatiques au run V2.
+- Oui, possibilité de tracer précisément les scénarios perdants pour corriger la dynamique NX.


### PR DESCRIPTION
### Motivation
- Provide an isolated staging area to integrate the V2 algorithmic benchmark without modifying the official simulator sources. 
- Add an auditable, per-scenario forensic benchmark and RNG modes to reproduce and explain the reported NX vs baseline win-rate. 
- Supply tooling to build and run the staging code easily in CI/Replit and to produce a full JSONL forensic trace for analysis.

### Description
- Added a staging tree under `src/advanced_calculations/quantum_simulator_v2_staging/` containing a copied `quantum_simulator.c` and `quantum_simulator.h` (kept identical to the official versions) plus new fusion files `quantum_simulator_fusion_v2.c` and `quantum_simulator_fusion_v2.h` which implement `quantum_fusion_v2_run_forensic_benchmark`, RNG modes, and a `quantum_fusion_v2_summary_t` summary. 
- Introduced `quantum_simulator_fusion_v2` RNG modes (`QUANTUM_RNG_HARDWARE_ONLY`, `QUANTUM_RNG_HARDWARE_PREFERRED`, `QUANTUM_RNG_DETERMINISTIC_SEEDED`) and hardware-seeding logic with fallback behavior and explicit failure for hardware-only mode. 
- Added a Replit-friendly runner script `run_on_replit.sh` that compiles tests (`src/tests/test_quantum_simulator_complete.c`) and the fusion runner, executes the fusion benchmark, and writes `results/fusion_forensic_full.jsonl`; removed the versioned binary object `quantum_simulator.o`. 
- Added documentation and analysis artifacts (`PLAN_FUSION_V2_QUANTUM_SIMULATOR_OFFICIEL.md`, `RAPPORT_AVANT_APRES_FUSION_V2.md`, `ANALYSE_VKERNEL_NQUBIT_V2_ET_V6_20260302.md`) describing the plan, differences, and observed KPI (e.g. the 65.3% win rate from a 360-scenario run).

### Testing
- Compiled the staging code and tests with `gcc -DMODULES_QUANTIQUES_ACTIFS` as invoked by `run_on_replit.sh` and the build completed successfully. 
- Executed the existing unit/executable test `src/tests/test_quantum_simulator_complete.c` via the generated binary and it ran without error in the runner flow. 
- Built and ran the fusion runner which executed `quantum_fusion_v2_run_forensic_benchmark` and produced `results/fusion_forensic_full.jsonl` and a printed summary (`wins`, `losses`, `win_rate`, `nqubits_per_sec`, `hw_entropy`), and the runner finished successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ed8531308323a9021f8e15fba867)