### PR TITLE
Fix overflow in forensic RMSE and add Replit correction report

### DIFF
--- a/src/advanced_calculations/quantum_problem_hubbard_hts/RAPPORT_CORRECTION_OVERFLOW_REPLIT_20260312.md
+++ b/src/advanced_calculations/quantum_problem_hubbard_hts/RAPPORT_CORRECTION_OVERFLOW_REPLIT_20260312.md
@@ -1,0 +1,81 @@
+# RAPPORT DE CORRECTION — Overflow post-run forensic (Replit, 2026-03-12)
+
+## 1) Synchronisation dépôt distant (sans récupérer de binaire)
+- Dépôt synchronisé depuis `https://github.com/lumc01/Lumvorax.git` via fetch Git uniquement.
+- Vérification: le commit distant pointé par `FETCH_HEAD` est identique au `HEAD` local (`55fcb5af...`), donc le dépôt local était déjà à jour.
+- Aucun téléchargement d’artefacts binaires, aucun `git lfs pull`, aucun import ZIP.
+
+## 2) Symptôme observé
+Pendant le cycle:
+- `post_run_forensic_extension_tests.py` échoue avec:
+  - `OverflowError: (34, 'Numerical result out of range')`
+  - origine: calcul RMSE sur `(a - b) ** 2`
+- Ensuite `post_run_full_scope_integrator.py` échoue par propagation (`CalledProcessError`, `check=True`).
+
+## 3) Cause racine exacte
+Le flux fautif est:
+1. Le modèle power-law en validation croisée calcule `exp(la + lb * log(x))`.
+2. Certaines combinaisons de données produisent des prédictions extrêmes.
+3. Le RMSE carré (`(a-b)^2`) déborde en flottant.
+4. Le script lève une exception et casse la chaîne post-run.
+
+## 4) Correctifs implémentés (code)
+Fichier corrigé:
+- `src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py`
+
+### 4.1 Garde-fous numériques globaux
+- `MAX_EXP_ARG = 700.0` (borne stable pour `exp` en float64)
+- `MAX_SAFE_MAG = 1e154` (borne avant carré)
+
+### 4.2 Fonctions robustes ajoutées
+- `safe_square(x)`
+  - renvoie `inf` si `x` non-fini ou trop grand
+  - sinon calcule `x*x`
+- `safe_exp(x)`
+  - borne l’argument dans `[-700, 700]`
+  - évite les overflows de `exp`
+
+### 4.3 RMSE robuste
+- `rmse()`:
+  - ignore les paires non-finies
+  - utilise `safe_square` + `math.fsum`
+  - renvoie `inf` si aucune paire exploitable (au lieu d’exception)
+
+### 4.4 Validation croisée robuste
+- Prédiction power-law migrée de `math.exp(...)` vers `safe_exp(...)`.
+- Le statut `PASS` est maintenant strict:
+  - uniquement si RMSE power et linéaire sont **finies** et `rmse_pow <= rmse_lin`
+  - sinon statut `OBSERVED` (pipeline continue)
+
+## 5) Vérification d’intégrité des données/résultats
+- Le script réparé exécute la génération des artefacts:
+  - `integration_forensic_extension_tests.csv`
+  - `integration_test_coverage_dashboard.csv`
+  - `forensic_extension_summary.json`
+- Aucun crash sur le run historique incriminé.
+
+## 6) Ce qui manquait à préciser (ajouts)
+1. Le bug est **post-traitement Python**, pas compilation C ni solveur principal.
+2. Le comportement attendu en valeurs extrêmes doit être **dégradation contrôlée** (`OBSERVED`) et non arrêt brutal.
+3. Les non-finies doivent être auditables dans les CSV (`inf`, `nan`) pour analyse scientifique ultérieure.
+4. Reproductibilité: commande d’exécution exacte ci-dessous.
+
+## 7) Commandes exactes reproductibles (Replit)
+Depuis la racine repo:
+
+```bash
+git fetch --no-tags https://github.com/lumc01/Lumvorax.git
+bash src/advanced_calculations/quantum_problem_hubbard_hts/run_research_cycle.sh
+```
+
+Validation isolée du correctif (sur un run existant):
+
+```bash
+python3 src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py \
+  src/advanced_calculations/quantum_problem_hubbard_hts/results/research_20260312T173817Z_1335
+```
+
+## 8) Recommandations complémentaires (non bloquantes)
+- Ajouter un indicateur `numeric_guard_triggered` dans la sortie CSV.
+- Ajouter un test CI synthétique “extrêmes numériques” pour forcer des valeurs limites et valider l’absence de crash.
+- Optionnel: journaliser le nombre de points exclus (non-finies) par test pour diagnostic rapide.

--- a/src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py
+++ b/src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from statistics import mean
 
 
+MAX_EXP_ARG = 700.0
+MAX_SAFE_MAG = 1e154
+
+
 def read_csv(path: Path):
     with path.open(newline="", encoding="utf-8") as f:
         return list(csv.DictReader(f))
@@ -51,9 +55,29 @@ def linreg(x, y):
 
 
 def rmse(y_true, y_pred):
-    if not y_true:
-        return 0.0
-    return math.sqrt(sum((a - b) ** 2 for a, b in zip(y_true, y_pred)) / len(y_true))
+    finite_pairs = [
+        (a, b)
+        for a, b in zip(y_true, y_pred)
+        if math.isfinite(a) and math.isfinite(b)
+    ]
+    if not finite_pairs:
+        return float("inf")
+    squared = [safe_square(a - b) for a, b in finite_pairs]
+    return math.sqrt(math.fsum(squared) / len(finite_pairs))
+
+
+def safe_square(x):
+    if not math.isfinite(x):
+        return float("inf")
+    if abs(x) > MAX_SAFE_MAG:
+        return float("inf")
+    return x * x
+
+
+def safe_exp(x):
+    if not math.isfinite(x):
+        return float("inf")
+    return math.exp(max(-MAX_EXP_ARG, min(MAX_EXP_ARG, x)))
 
 
 def alpha_from_series(rows):
@@ -109,7 +133,7 @@ def kfold_compare_models(rows, k=5):
         lx = [math.log(v + eps) for v in xtr]
         ly = [math.log(v + eps) for v in ytr]
         la, lb = linreg(lx, ly)
-        yhat_pow = [math.exp(la + lb * math.log(v + eps)) for v in xte]
+        yhat_pow = [safe_exp(la + lb * math.log(v + eps)) for v in xte]
 
         rmse_lin.append(rmse(yte, yhat_lin))
         rmse_pow.append(rmse(yte, yhat_pow))
@@ -216,7 +240,7 @@ def main():
         out_rows.append({"test_family": "bootstrap_alpha", "test_id": f"alpha_ci95_{problem}", "parameter": "alpha_ci95_width", "value": round(hi - lo, 10), "status": status, "details": f"alpha={est:.8f};ci95=[{lo:.8f},{hi:.8f}]"})
 
         rmse_pow, rmse_lin = kfold_compare_models(rows)
-        status = "PASS" if rmse_pow <= rmse_lin else "OBSERVED"
+        status = "PASS" if (math.isfinite(rmse_pow) and math.isfinite(rmse_lin) and rmse_pow <= rmse_lin) else "OBSERVED"
         out_rows.append({"test_family": "cross_validation", "test_id": f"scaling_model_{problem}", "parameter": "rmse_power_minus_linear", "value": round(rmse_pow - rmse_lin, 10), "status": status, "details": f"rmse_power={rmse_pow:.10f};rmse_linear={rmse_lin:.10f}"})
 
         energy = [to_float(r["energy"]) for r in rows]


### PR DESCRIPTION
### Motivation
- A `OverflowError` was raised in the forensic post-run when `(a - b) ** 2` overflowed due to extreme power-law predictions, causing the post-run integrator to fail. 
- The post-processing must degrade gracefully on extreme numeric values so the pipeline continues and artifacts are produced for analysis. 

### Description
- Added numeric guard constants `MAX_EXP_ARG` and `MAX_SAFE_MAG` and helper functions `safe_exp(x)` and `safe_square(x)` in `src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py`. 
- Rewrote `rmse()` to filter non-finite pairs, use `safe_square` and `math.fsum`, and return `inf` when no valid pairs remain. 
- Replaced direct `math.exp(...)` calls for the power-law predictor with `safe_exp(...)` and tightened cross-validation `PASS` logic to require finite RMSE values before declaring `PASS`. 
- Added a new report `src/advanced_calculations/quantum_problem_hubbard_hts/RAPPORT_CORRECTION_OVERFLOW_REPLIT_20260312.md` documenting root cause, exact fixes and reproducible commands. 

### Testing
- Ran `python3 src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_forensic_extension_tests.py <failing_run_dir>` on the problematic run directory and it completed, writing `integration_forensic_extension_tests.csv`, `integration_test_coverage_dashboard.csv` and `forensic_extension_summary.json` (success). 
- Ran `python3 src/advanced_calculations/quantum_problem_hubbard_hts/tools/post_run_full_scope_integrator.py <failing_run_dir>` and the full integrator completed and generated expected artifacts without raising the earlier `OverflowError` (success). 
- No binaries were fetched or introduced during the change and all automated runs above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ffe1b1cc832082fea8dc0cf940a3)