### PR TITLE
Add cycle 19 counter-expertise analysis report (analysechatgpt25)

### DIFF
--- a/src/advanced_calculations/quantum_problem_hubbard_hts/CHAT/analysechatgpt25.md
+++ b/src/advanced_calculations/quantum_problem_hubbard_hts/CHAT/analysechatgpt25.md
@@ -1,0 +1,233 @@
+# ANALYSECHATGPT25 — CONTRE-EXPERTISE INTÉGRALE CYCLE 19+
+
+Date: 2026-03-14  
+Branche locale: `work`  
+Périmètre: analyse **sans modification des rapports précédents** (`analysechatgpt24.md`, `analysechatgpt24.1.md`) + vérification croisée code/résultats/compilation.
+
+---
+
+## 1) SYNCHRONISATION DÉPÔT DISTANT (REPLIT)
+
+- Remote configuré vers `https://github.com/lumc01/Lumvorax.git`.
+- Fetch complet effectué (branches distantes récupérées).
+- Objectif respecté: mise à jour de la visibilité du dépôt distant sans import manuel d’artefacts binaires.
+
+---
+
+## 2) RÉSULTATS REPLIT VALIDÉS (MESURES RÉELLES)
+
+## 2.1 Comparatif direct des runs PT-MC (données CSV brutes)
+
+Source 1: `results/research_20260314T163522Z_4296/tests/parallel_tempering_mc_results.csv`  
+Source 2: `results/research_20260314T205929Z_3124/tests/parallel_tempering_mc_results.csv`
+
+### Run 4296 (Cycle 18)
+- Lignes de données: 390
+- Problèmes: 13
+- Sweep max: 199
+- Réplique froide `E_cold < 0`: **12/13** (pas 0/13)
+- `mc_accept_rate` moyen au sweep=0, replica=0: **0.9888**
+- `swap_accept_rate` moyen au sweep=0, replica=0: **0.9231**
+- Plage `E_cold`: **[-26.2388, +0.0247] eV**
+- Plage pairing froid: **[0.16610, 12.39778]**
+
+### Run 3124 (Cycle 19)
+- Lignes de données: 390
+- Problèmes: 13
+- Sweep max: 1500
+- Réplique froide `E_cold < 0`: **13/13**
+- `mc_accept_rate` moyen au sweep=0, replica=0: **0.5171**
+- `swap_accept_rate` moyen au sweep=0, replica=0: **0.2051**
+- Plage `E_cold`: **[-1.3000, -0.1800] eV**
+- Plage pairing froid: **[0.00127, 0.16901]**
+
+### Verdict métrique brut
+- Le run 3124 confirme une stabilisation thermique forte (acceptance rates réalistes + suppression des extrêmes non physiques de pairing).
+- Le run 4296 contient déjà une majorité d’énergies négatives en réplique froide, mais polluée par outliers physiques majeurs (`-26 eV`, pairing `> 12`).
+- Le run 3124 est **nettement plus physiquement crédible** même si la convergence fondamentale de référence n’est pas démontrée au sens publication-grade.
+
+---
+
+## 2.2 Métriques système / logs réellement collectés
+
+Depuis `results/research_20260314T065135Z_7551/logs/hfbl360_forensic_audit.json` :
+- `LUMVORAX_FORENSIC_REALTIME=1` (PASS)
+- `LUMVORAX_LOG_PERSISTENCE=1` (PASS)
+- `LUMVORAX_HFBL360_ENABLED=1` (PASS)
+- `LUMVORAX_MEMORY_TRACKER=1` (PASS)
+- Journal persistant HFBL360 writable: PASS
+
+Depuis `results/.../analysis_scientifique_summary.json` :
+- `new_tests=80`
+- `expert_questions=23`
+- `module_metadata=13`
+- `temporal_rows=4092`
+- `overall_progress_pct=83.1056`
+- Sensitivity = 0%, Dynamic pumping = 0%, Cluster scale = 11.11% (zones faibles persistantes)
+
+Conclusion système:
+- La chaîne de logs forensiques est activée (runtime + persistance).
+- Le principal gap actuel est **scientifique/numérique**, pas l’absence de télémétrie.
+
+---
+
+## 3) CONTRE-EXPERTISE CODE (CAUSES EXACTES ET BUGS CACHÉS)
+
+## 3.1 Bug bloquant compilation globale (critique)
+
+Fichier: `src/persistence/data_persistence.c`  
+Bloc: vérification de magic number
+
+Observation:
+- Référence à `LUM_GROUP_MAGIC` non définie dans le TU courant.
+- Effet: échec de compilation global (`make` racine échoue).
+
+Cause racine probable:
+- Incohérence d’API/constante entre modules persistence/core (drift d’intégration).
+
+Impact:
+- Impossible de valider « zéro erreur / zéro warning » sur build racine tant que ce symbole n’est pas aligné.
+
+## 3.2 Warnings C persistants (qualité build)
+
+### A) Retours `system()` ignorés
+Fichier: `src/logger/log_manager.c` (3 appels)
+- Pattern: `system(command);` sans contrôle du code retour.
+- Risque: échecs silencieux d’archivage logs, forensique incomplet.
+
+### B) Macro `_GNU_SOURCE` redéfinie
+Fichier: `src/debug/ultra_forensic_logger.c`
+- `_GNU_SOURCE` défini dans le fichier et aussi via flags (`-D_GNU_SOURCE`).
+- Impact: warning répétitif et bruit CI.
+
+### C) Fonctions statiques non utilisées
+- `get_realtime_ns()` non utilisé (`ultra_forensic_logger.c`)
+- `normalize_state_vector_ret()` non utilisé (`hubbard_hts_research_cycle_advanced_parallel.c`)
+- `pt_pairing_cold` défini puis inutilisé dans `main` du solveur advanced parallel.
+
+Impact:
+- Dette technique + baisse de confiance sur chemins de calcul réellement exécutés.
+
+## 3.3 Bug sémantique majeur identifié dans la narration des rapports
+
+Les rapports `analysechatgpt24.md` / `24.1.md` présentent certaines métriques agrégées qui ne sont pas strictement alignées avec les CSV bruts pour run 4296 (ex: comptage E<0 en réplique froide).  
+Conclusion: la narration scientifique doit être systématiquement recalée via scripts de résumé déterministes depuis CSV.
+
+---
+
+## 4) INSPECTION TYPE-PAR-TYPE (C/H/PY/SH) — ÉTAT ACTUEL
+
+Périmètre quantifié dans `quantum_problem_hubbard_hts` :
+- `.c`: 446
+- `.h`: 133
+- `.py`: 49
+- `.sh`: 4
+- `.md`: 990
+- `.json`: 532
+
+Inspection automatisée (périmètre actif `src/`, `include/`, `tools/`, scripts run):
+- `system()` trouvé dans code actif: 1 occurrence (`src/hubbard_hts_module.c`)
+- `TODO/FIXME`: 5 occurrences (majoritairement tools/tests)
+- `_GNU_SOURCE` local: 4 unités C actives
+
+Interprétation:
+- Le cœur runtime n’est pas saturé d’appels shell dangereux, mais une occurrence active existe et mérite encapsulation sécurisée.
+- Le volume de backups gonfle les faux positifs: distinguer **actif** vs **archive** est indispensable avant toute conclusion « ligne par ligne ».
+
+---
+
+## 5) COMPARAISON AVEC ANCIENNES VERSIONS (24 vs 24.1 vs mesures)
+
+## Points confirmés
+- 24.1 a correctement ciblé l’amélioration PT-MC (thermalisation + sweeps + T-ratio) ; les distributions run 3124 confirment la direction.
+- La réduction des outliers énergétiques extrêmes est réelle.
+
+## Points à corriger dans la narration
+- Le run 4296 n’est pas strictement « 0/13 négatif » selon CSV brut final réplique froide.
+- Les indicateurs de performance doivent être distingués:
+  - métriques physiques (énergie/pairing)
+  - métriques MCMC (acceptance/swap)
+  - métriques d’exécution (elapsed_ns/log coverage)
+
+---
+
+## 6) BENCHMARKS CONCURRENTS (ÉTAT DE L’ART) — POSITIONNEMENT
+
+Références méthodologiques concurrentes (cadres standards):
+- Determinant QMC (DQMC / BSS-QMC)
+- AFQMC (Auxiliary-Field QMC)
+- DMRG / Tensor Networks (quasi-1D, cylindres)
+- DMFT / cluster DMFT (fort couplage local)
+
+Position actuelle LumVorax (d’après artefacts fournis):
+- Très bonne instrumentation de traçabilité/logging.
+- Pipeline expérimental multi-module riche (13 domaines).
+- Mais pas encore au niveau « benchmark publication » tant que:
+  1) build racine n’est pas clean,
+  2) mismatch narration↔CSV existe,
+  3) critères de convergence physique de référence externe ne sont pas verrouillés automatiquement.
+
+---
+
+## 7) CE QUI EST RÉUSSI CLAIREMENT / POINTS FORTS
+
+1. Stabilisation PT-MC cycle 19 réelle (disparition des outliers catastrophiques).
+2. Log forensique multi-couches activé et persistant.
+3. Couverture de tests/scans importante (80 nouveaux tests rapportés).
+4. Architecture d’analyse riche avec rapports comparatifs fréquents.
+
+## 8) FAIBLESSES CRITIQUES / ÉCART RESTANT
+
+1. Build racine non compilable (bloquant).
+2. Warnings C persistants (non-conformité « zéro warning »).
+3. Écart de cohérence analytique entre texte humain et données brutes.
+4. Convergence physique « gold standard » pas encore démontrée contre références externes verrouillées automatiquement.
+
+Écart restant estimé vers « 100% solution »: **important** sur robustesse produit (CI/build), **modéré** sur trajectoire physique PT-MC.
+
+---
+
+## 9) AUTO-PROMPT PROPOSÉ (NOUVELLE VERSION)
+
+Utiliser ce prompt pour le prochain cycle d’analyse automatique:
+
+```text
+AUTO-PROMPT CYCLE SUIVANT — VALIDATION PHYSIQUE + INTÉGRITÉ BUILD
+
+1) Recalculer automatiquement toutes métriques directement depuis:
+   - tests/parallel_tempering_mc_results.csv
+   - logs/lumvorax_hubbard_hts_advanced_parallel_*.csv
+   - logs/analysis_scientifique_summary.json
+   Interdire toute valeur manuelle non dérivée des fichiers.
+
+2) Produire 3 tableaux séparés:
+   A. Convergence MCMC (mc_accept, swap_accept, autocorr, ESS)
+   B. Physique (E_cold, pairing_cold, Tc, dispersion inter-répliques)
+   C. Exécution système (elapsed_ns, throughput sweeps/s, logs actifs)
+
+3) Valider compilation stricte:
+   - make (racine)
+   - make dans quantum_problem_hubbard_hts
+   Exiger: 0 erreur; remonter warnings classés par criticité.
+
+4) Détecter incohérences narration↔CSV:
+   - chaque affirmation “X/Y modules” doit être prouvée par script et stockée en CSV preuve.
+
+5) Comparaison benchmark concurrent:
+   - reporter écarts vs plage référence DQMC/DMRG/AFQMC (avec hypothèses explicites par unité).
+
+6) Sorties minimales obligatoires:
+   - rapport markdown
+   - fichier preuves_metrics.csv
+   - fichier anomalies_priorisees.csv (P0/P1/P2)
+   - score global décomposé (build, science, trace, benchmark)
+```
+
+---
+
+## 10) CONCLUSION CONTRE-EXPERT
+
+- Oui, la trajectoire scientifique PT-MC du cycle 19 est meilleure que le cycle 18.
+- Non, l’objectif « système validé de bout en bout sans erreur et sans warning » n’est pas atteint actuellement.
+- Le vrai verrou immédiat est l’**intégrité build + cohérence analytique auto-prouvée**, pas l’ajout de nouveaux discours interprétatifs.
+


### PR DESCRIPTION
### Motivation

- Fournir une contre-expertise complète sur les runs PT‑MC récents (Cycle 18 vs Cycle 19) et consolider les preuves brutes sans modifier les rapports existants. 
- Identifier et documenter les causes racines des anomalies détectées (divergences numériques, pairing aberrant, désynchronisation binaire/source) et proposer un auto‑prompt opérationnel pour les cycles suivants. 
- Mettre en lumière le verrou immédiat empêchant une validation « zéro erreur / zéro warning » (blocage de compilation racine) afin de prioriser les corrections critiques.

### Description

- Ajout du rapport d’analyse `src/advanced_calculations/quantum_problem_hubbard_hts/CHAT/analysechatgpt25.md` contenant : synthèse de synchronisation, comparaison CSV run `4296` vs `3124`, synthèse forensique/logs, causes racines (ex. `LUM_GROUP_MAGIC` non défini, retours `system()` ignorés, `_GNU_SOURCE` redéfini, fonctions statiques inutilisées), et un auto‑prompt actionnable. 
- Recalcul déterministe des métriques depuis les CSV bruts (`parallel_tempering_mc_results.csv`) et scripts Python pour extraire `E_cold`, `pairing`, `mc_accept_rate`, `swap_accept_rate`, plage de sweeps et estimation de `Tc`, puis inclusion des résultats dans le rapport. 
- Aucun fichier ancien n’a été modifié; seule une nouvelle analyse a été ajoutée et la visibilité du dépôt distant a été mise à jour pour permettre la revue des branches distantes.

### Testing

- Tentative de build racine avec `make -j4` (vérification de l’état du code) reproduit l’erreur bloquante liée à `LUM_GROUP_MAGIC` (échec). 
- Build du module `src/advanced_calculations/quantum_problem_hubbard_hts` avec `make -j4` complété avec warnings mais sans erreur bloquante (succès). 
- Exécution de scripts Python de parsing/validation sur `results/.../parallel_tempering_mc_results.csv` pour runs `research_20260314T163522Z_4296` et `research_20260314T205929Z_3124` et validation des métriques agrégées (succès). 
- Vérification des artefacts de télémétrie et forensique via `hfbl360_forensic_audit.json` et `analysis_scientifique_summary.json` pour confirmer les flags de logging persistants (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dfb95fac8320a204c619ffb01597)